### PR TITLE
Fix CentralBuildOutputPath validation

### DIFF
--- a/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
@@ -14,6 +14,34 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
     }
 
     /// <summary>
+    /// Validates that the CentralBuildOutputPath must be set.
+    ///     Directory.Build.props
+    ///     Directory.Build.targets
+    ///     nuget.config
+    ///     src/MyClassLibrary/MyClassLibrary.csproj
+    /// </summary>
+    [Fact]
+    public void CentralBuildOutputPathMustBeSet()
+    {
+        // Arrange
+        this.SetupDirectoryBuildProps(centralBuidOutputPath: string.Empty);
+
+        // Act
+        ProjectCreator.Templates
+            .SdkCsproj(path: "src/MyClassLibrary/MyClassLibrary.csproj")
+            .Save()
+            .TryRestore(out bool restoreResult, out BuildOutput buildOutput);
+
+        // Assert
+        restoreResult.ShouldBeFalse();
+        buildOutput.Errors.Count.ShouldBe(1);
+        string buildError = buildOutput.Errors.ElementAt(0);
+        buildError.ShouldBeEquivalentTo("CentralBuildOutputPath must be set before importing the CentralBuildOutput project SDK.");
+
+        buildOutput.Dispose();
+    }
+
+    /// <summary>
     /// Validates a project in a project folder:
     ///     Directory.Build.props
     ///     Directory.Build.targets

--- a/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
+++ b/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
@@ -11,11 +11,15 @@
       Log an error if CentralBuildOutputPath has not been set.
     -->
     <Error
-      Text="CentralBuildOutputPath must be set before importing $(MSBuildThisFile)."
+      Text="CentralBuildOutputPath must be set before importing the CentralBuildOutput project SDK."
       Condition=" '$(CentralBuildOutputPath)' == '' " />
   </Target>
 
-  <PropertyGroup Condition=" '$(EnableCentralBuildOutput)' != 'false' ">
+  <PropertyGroup>
+    <CentralBuildOutputEnabledAndReady Condition=" '$(EnableCentralBuildOutput)' != 'false' And '$(CentralBuildOutputPath)' != '' ">true</CentralBuildOutputEnabledAndReady>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(CentralBuildOutputEnabledAndReady)' == 'true' ">
     <!-- Allow the user to override the folder prefix. Defaults to '__' -->
     <CentralBuildOutputFolderPrefix Condition=" '$(CentralBuildOutputFolderPrefix)' == '' ">__</CentralBuildOutputFolderPrefix>
 
@@ -66,7 +70,7 @@
     <BaseProjectTestResultsOutputPath>$(BaseTestResultsDir)$(RelativeProjectPath)</BaseProjectTestResultsOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(EnableCentralBuildOutput)' != 'false' And $(MSBuildProjectFile.EndsWith('.csproj')) ">
+  <PropertyGroup Condition=" $(MSBuildProjectFile.EndsWith('.csproj')) And '$(CentralBuildOutputEnabledAndReady)' == 'true' ">
     <ProjectIntermediateOutputPath>$(BaseProjectIntermediateOutputPath)</ProjectIntermediateOutputPath>
 
     <BaseIntermediateOutputPath>$(ProjectIntermediateOutputPath)</BaseIntermediateOutputPath>


### PR DESCRIPTION
  - This change adds a test for the `CentralBuildOutputPath` property validation.
  - This change fixes the validation to ensure that `CentralBuildOutputPath` is set. It turns out that all properties are imported even before `InitialTargets` are run, so we hit an error with the `[MSBuild]::MakeRelative` line. I've added a property to guard the logic when its not set so that the `CheckCentralBuildOutputProperties` target has a chance to run and provide the appropriate error message.