### PR TITLE
Update to version 0.1.1-beta.3

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,6 +7,6 @@
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.1.3",
     "Microsoft.Build.NoTargets": "3.3.0",
-    "Treasure.Build.CentralBuildOutput": "0.1.1-beta.1"
+    "Treasure.Build.CentralBuildOutput": "0.1.1-beta.3"
   }
 }

--- a/samples/CentralBuildOutput/Directory.Build.props
+++ b/samples/CentralBuildOutput/Directory.Build.props
@@ -9,5 +9,5 @@
   </PropertyGroup>
 
   <!-- Import the CentralBuildOutput SDK. -->
-  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="0.1.1-beta.1" />
+  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="0.1.1-beta.3" />
 </Project>


### PR DESCRIPTION
  - This change updates our consumption of CentralBuildOutput to 0.1.1-beta.3.