### PR TITLE
Add support for Microsoft.Build.Traversal projects

### DIFF
--- a/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
+++ b/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
@@ -19,6 +19,21 @@
     <CentralBuildOutputEnabledAndReady Condition=" '$(EnableCentralBuildOutput)' != 'false' And '$(CentralBuildOutputPath)' != '' ">true</CentralBuildOutputEnabledAndReady>
   </PropertyGroup>
 
+  <!--
+    When using Microsoft.Build.Traversal (https://github.com/microsoft/MSBuildSdks/tree/main/src/Traversal),
+    it is unlikely that their props will be imported in time for us to reference their properties. So, we need to
+    configure a few of their properties beforehand here. These properties are copied from their props file in order
+    for us to be able to properly influence the output of a Traversal project.
+  -->
+  <PropertyGroup Condition=" '$(UsingMicrosoftTraversalSdk)' == 'true' ">
+    <!--
+      A list of project names that are considered traversal projects.  Add to this list if you name your projects something other than "dirs.proj"
+    -->
+    <TraversalProjectNames Condition=" '$(TraversalProjectNames)' == '' ">dirs.proj</TraversalProjectNames>
+
+    <IsTraversal Condition=" '$(IsTraversal)' == '' And $(TraversalProjectNames.IndexOf($(MSBuildProjectFile), System.StringComparison.OrdinalIgnoreCase)) >= 0 ">true</IsTraversal>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(CentralBuildOutputEnabledAndReady)' == 'true' ">
     <!-- Allow the user to override the folder prefix. Defaults to '__' -->
     <CentralBuildOutputFolderPrefix Condition=" '$(CentralBuildOutputFolderPrefix)' == '' ">__</CentralBuildOutputFolderPrefix>
@@ -30,6 +45,12 @@
       when the the paths are equal.
     -->
     <RelativeProjectPath Condition=" '$(MSBuildProjectDirectory)\' == '$(CentralBuildOutputPath)' "></RelativeProjectPath>
+
+    <!--
+      Traversal projects are generally not placed inside a project folder of their own. So, we append the project name
+      to cause their output to be contained to a folder.
+     -->
+    <RelativeProjectPath Condition=" '$(IsTraversal)' == 'true' ">$(RelativeProjectPath)$(MSBuildProjectName)/</RelativeProjectPath>
 
     <!--
       Allow the user to redefine the root folder used to calculate the relative output structure. For example, to remove
@@ -70,7 +91,16 @@
     <BaseProjectTestResultsOutputPath>$(BaseTestResultsDir)$(RelativeProjectPath)</BaseProjectTestResultsOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" $(MSBuildProjectFile.EndsWith('.csproj')) And '$(CentralBuildOutputEnabledAndReady)' == 'true' ">
+  <PropertyGroup Condition=" '$(CentralBuildOutputEnabledAndReady)' == 'true' ">
+    <CentralBuildOutputDotNetStyleProject Condition=" $(MSBuildProjectFile.EndsWith('.csproj')) ">true</CentralBuildOutputDotNetStyleProject>
+
+    <CentralBuildOutputTraversalProject Condition=" '$(IsTraversal)' == 'true' ">true</CentralBuildOutputTraversalProject>
+  </PropertyGroup>
+
+  <!--
+    Configure .NET style project output.
+  -->
+  <PropertyGroup Condition=" '$(CentralBuildOutputDotNetStyleProject)' == 'true' ">
     <ProjectIntermediateOutputPath>$(BaseProjectIntermediateOutputPath)</ProjectIntermediateOutputPath>
 
     <BaseIntermediateOutputPath>$(ProjectIntermediateOutputPath)</BaseIntermediateOutputPath>
@@ -80,6 +110,15 @@
     <PublishDir>$(BaseProjectPublishOutputPath)</PublishDir>
     <VSTestResultsDirectory>$(BaseProjectTestResultsOutputPath)</VSTestResultsDirectory>
     <CoverletOutput>$(BaseProjectTestResultsOutputPath)</CoverletOutput>
+  </PropertyGroup>
+
+  <!--
+    Configure Traversal project output.
+  -->
+  <PropertyGroup Condition=" '$(CentralBuildOutputTraversalProject)' == 'true' ">
+    <BaseIntermediateOutputPath>$(BaseProjectIntermediateOutputPath)</BaseIntermediateOutputPath>
+    <MSBuildProjectExtensionPath>$(BaseProjectIntermediateOutputPath)</MSBuildProjectExtensionPath>
+    <OutputPath>$(ProjectOutputPath)</OutputPath>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
  - Projects using [Microsoft.Build.Traversal](https://github.com/microsoft/MSBuildSdks/tree/main/src/Traversal) don't really have useful output, but they do emit some intermediates during the NuGet restore. This change configures that output to be directed into the centralized build output folder in a folder with the project name. To do this, I had to declare some of the [properties from Microsoft.Build.Traversal](https://github.com/microsoft/MSBuildSdks/blob/main/src/Traversal/Sdk/Sdk.props) earlier so that I could tell if the project was a traversal project. This fixes #18.
 
Note: The use of the `/pp:preprocessed.xml` MSBuild parameter was invaluable while determining the order in which properties are declared. I haven't seen that in Structured Log Viewer, but I could be missing something.