### PR TITLE
Configure default platform and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,13 @@ Setting the following properties controls how Central Build Output works.
 | ---                                     | ---                                                                                                  |
 | `CentralBuildOutputPath` (Required)     | Defines the output path of the build output folders.                                                 |
 | `CentralBuildOutputFolderPrefix`        | Overrides the output folder prefix. Default is `__`.                                                 |
+| `CentralBuildOutputNoDefaultPlatform`   | Omits the default platform name in the output path unless necessary if set to `true`.                |
 | `CentralBuildOutputRelativeToPath`      | Redefines the root folder used to calculate the relative folder used in build output folders.        |
 | `CustomBeforeCentralBuildOutputProps`   | A list of custom MSBuild projects to import **before** central build output properties are declared. |
 | `CustomAfterCentralBuildOutputProps`    | A list of custom MSBuild projects to import **after** central build output properties are declared.  |
 | `CustomBeforeCentralBuildOutputTargets` | A list of custom MSBuild projects to import **before** central build output targets are declared.    |
 | `CustomAfterCentralBuildOutputTargets`  | A list of custom MSBuild projects to import **after** central build output targets are declared.     |
-| `EnableCentralBuildOutput`              | Indicates whether central build output is enabled or not. Set to `false` to disable.
+| `EnableCentralBuildOutput`              | Indicates whether central build output is enabled or not. Set to `false` to disable.                 |
 
 ## Controlling SDK versions
 

--- a/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
@@ -62,388 +62,6 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
         Properties properties = Properties.Load(project);
 
         CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
-        cboProps.AppxPackageDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/src/MyClassLibrary/AppPackages/");
-        cboProps.BaseIntDir.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/");
-        cboProps.BaseNuGetDir.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/");
-        cboProps.BaseOutDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/");
-        cboProps.BasePackagesDir.MakeRelative(this.ProjectOutput).ShouldBe("__packages/");
-        cboProps.BaseProjectIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/src/MyClassLibrary/");
-        cboProps.BaseProjectPublishOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/src/MyClassLibrary/");
-        cboProps.BaseProjectTestResultsOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/src/MyClassLibrary/");
-        cboProps.BasePublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/");
-        cboProps.BaseTestResultsDir.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/");
-        cboProps.CentralBuildOutputFolderPrefix.MakeRelative(this.ProjectOutput).ShouldBe("__");
-        cboProps.CentralBuildOutputPath.MakeRelative(this.ProjectOutput).ShouldBeEmpty();
-        cboProps.DefaultArtifactsSource.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/Debug/");
-        cboProps.EnableCentralBuildOutput.MakeRelative(this.ProjectOutput).ShouldBeEmpty();
-        cboProps.PackageOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/Debug/");
-        cboProps.ProjectIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/src/MyClassLibrary/");
-        cboProps.ProjectOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/src/MyClassLibrary/");
-        cboProps.RelativeProjectPath.MakeRelative(this.ProjectOutput).ShouldBe("src/MyClassLibrary/");
-
-        CoverletProperties coverletProps = properties.Coverlet;
-        coverletProps.CoverletOutput.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/src/MyClassLibrary/");
-
-        CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
-        msbuildProps.BaseIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/src/MyClassLibrary/");
-        msbuildProps.BaseOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/src/MyClassLibrary/");
-
-        // The target framework is added after CentralBuildOutput sets it, which adds a / or \ to the end
-        // depending on the OS. This is the reason for the ToPosixPath in this case.
-        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ToPosixPath()
-            .ShouldBe("__output/Debug/src/MyClassLibrary/netstandard2.0/");
-
-        CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
-        msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/src/MyClassLibrary/");
-
-        MSBuildOtherProperties msBuildOtherProps = properties.MSBuildOther;
-        msBuildOtherProps.MSBuildProjectExtensionPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/src/MyClassLibrary/");
-
-        VSTestProperties vsTestProps = properties.VSTest;
-        vsTestProps.VSTestResultsDirectory.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/src/MyClassLibrary/");
-
-        File.Exists("__output/Debug/src/MyClassLibrary/netstandard2.0/MyClassLibrary.dll").ShouldBeTrue();
-        Directory.Exists("__intermediate/src/MyClassLibrary/Debug/netstandard2.0").ShouldBeTrue();
-    }
-
-    /// <summary>
-    /// Validates a project in a project folder:
-    ///     Directory.Build.props
-    ///     Directory.Build.targets
-    ///     nuget.config
-    ///     src/MyClassLibrary/MyClassLibrary.csproj
-    /// </summary>
-    [Fact]
-    public void DefaultConfigurationWithMultiTargetting()
-    {
-        // Arrange
-        this.SetupDirectoryBuildProps();
-
-        // Act
-        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
-            .SdkCsproj(
-                path: "src/MyClassLibrary/MyClassLibrary.csproj",
-                targetFrameworks: new[] { "netstandard1.6", "netstandard2.0", "netstandard2.1" }));
-
-        // Assert
-        Properties properties = Properties.Load(project);
-
-        CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
-        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/src/MyClassLibrary/");
-
-        File.Exists("__output/Debug/src/MyClassLibrary/netstandard1.6/MyClassLibrary.dll").ShouldBeTrue();
-        File.Exists("__output/Debug/src/MyClassLibrary/netstandard2.0/MyClassLibrary.dll").ShouldBeTrue();
-        File.Exists("__output/Debug/src/MyClassLibrary/netstandard2.1/MyClassLibrary.dll").ShouldBeTrue();
-        Directory.Exists("__intermediate/src/MyClassLibrary/Debug/netstandard1.6").ShouldBeTrue();
-        Directory.Exists("__intermediate/src/MyClassLibrary/Debug/netstandard2.0").ShouldBeTrue();
-        Directory.Exists("__intermediate/src/MyClassLibrary/Debug/netstandard2.1").ShouldBeTrue();
-    }
-
-    /// <summary>
-    /// Validates a project in a project folder, but with CentralBuildOutputFolderPrefix set to "_prefix_":
-    ///     Directory.Build.props
-    ///     Directory.Build.targets
-    ///     nuget.config
-    ///     src/MyClassLibrary/MyClassLibrary.csproj
-    /// </summary>
-    [Fact]
-    public void PrefixOverride()
-    {
-        // Arrange
-        this.SetupDirectoryBuildProps(
-            projectFunction: p => p.Property("CentralBuildOutputFolderPrefix", "_prefix_"));
-
-        // Act
-        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
-            .SdkCsproj(path: "src/MyClassLibrary/MyClassLibrary.csproj"));
-
-        // Assert
-        Properties properties = Properties.Load(project);
-
-        CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
-        cboProps.BaseIntDir.MakeRelative(this.ProjectOutput).ShouldBe("_prefix_intermediate/");
-        cboProps.BaseOutDir.MakeRelative(this.ProjectOutput).ShouldBe("_prefix_output/");
-        cboProps.BasePackagesDir.MakeRelative(this.ProjectOutput).ShouldBe("_prefix_packages/");
-        cboProps.BasePublishDir.MakeRelative(this.ProjectOutput).ShouldBe("_prefix_publish/");
-        cboProps.BaseTestResultsDir.MakeRelative(this.ProjectOutput).ShouldBe("_prefix_test-results/");
-        cboProps.CentralBuildOutputFolderPrefix.MakeRelative(this.ProjectOutput).ShouldBe("_prefix_");
-
-        File.Exists("_prefix_output/Debug/src/MyClassLibrary/netstandard2.0/MyClassLibrary.dll").ShouldBeTrue();
-        Directory.Exists("_prefix_intermediate/src/MyClassLibrary/Debug/netstandard2.0").ShouldBeTrue();
-    }
-
-    /// <summary>
-    /// Validates a project in the root folder:
-    ///     Directory.Build.props
-    ///     Directory.Build.targets
-    ///     nuget.config
-    ///     MyClassLibrary.csproj
-    /// </summary>
-    [Fact]
-    public void ProjectInRoot()
-    {
-        // Arrange
-        this.SetupDirectoryBuildProps();
-
-        // Act
-        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
-            .SdkCsproj(path: Path.Combine(this.ProjectOutput, "MyClassLibrary.csproj")));
-
-        // Assert
-        Properties properties = Properties.Load(project);
-
-        CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
-        cboProps.AppxPackageDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AppPackages/");
-        cboProps.BaseIntDir.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/");
-        cboProps.BaseNuGetDir.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/");
-        cboProps.BaseOutDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/");
-        cboProps.BasePackagesDir.MakeRelative(this.ProjectOutput).ShouldBe("__packages/");
-        cboProps.BaseProjectIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/");
-        cboProps.BaseProjectPublishOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/");
-        cboProps.BaseProjectTestResultsOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/");
-        cboProps.BasePublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/");
-        cboProps.BaseTestResultsDir.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/");
-        cboProps.CentralBuildOutputFolderPrefix.MakeRelative(this.ProjectOutput).ShouldBe("__");
-        cboProps.CentralBuildOutputPath.MakeRelative(this.ProjectOutput).ShouldBeEmpty();
-        cboProps.DefaultArtifactsSource.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/Debug/");
-        cboProps.EnableCentralBuildOutput.MakeRelative(this.ProjectOutput).ShouldBeEmpty();
-        cboProps.PackageOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/Debug/");
-        cboProps.ProjectIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/");
-        cboProps.ProjectOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/");
-        cboProps.RelativeProjectPath.MakeRelative(this.ProjectOutput).ShouldBeEmpty();
-
-        CoverletProperties coverletProps = properties.Coverlet;
-        coverletProps.CoverletOutput.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/");
-
-        CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
-        msbuildProps.BaseIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/");
-        msbuildProps.BaseOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/");
-
-        // The target framework is added after CentralBuildOutput sets it, which adds a / or \ to the end
-        // depending on the OS. This is the reason for the ToPosixPath in this case.
-        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ToPosixPath()
-            .ShouldBe("__output/Debug/netstandard2.0/");
-
-        CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
-        msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/");
-
-        MSBuildOtherProperties msBuildOtherProps = properties.MSBuildOther;
-        msBuildOtherProps.MSBuildProjectExtensionPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/");
-
-        VSTestProperties vsTestProps = properties.VSTest;
-        vsTestProps.VSTestResultsDirectory.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/");
-    }
-
-    /// <summary>
-    /// Validates a project in a project folder, but with CentralBuildOutputRelativeToPath set to remove the src folder:
-    ///     Directory.Build.props
-    ///     Directory.Build.targets
-    ///     nuget.config
-    ///     src/MyClassLibrary/MyClassLibrary.csproj
-    /// </summary>
-    [Fact]
-    public void RelativePathOverride()
-    {
-        // Arrange
-        this.SetupDirectoryBuildProps(
-            projectFunction: p => p.Property("CentralBuildOutputRelativeToPath", Path.Combine(this.ProjectOutput, "src")));
-
-        // Act
-        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
-            .SdkCsproj(path: "src/MyClassLibrary/MyClassLibrary.csproj"));
-
-        // Assert
-        Properties properties = Properties.Load(project);
-
-        CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
-        cboProps.AppxPackageDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/MyClassLibrary/AppPackages/");
-        cboProps.BaseProjectIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/MyClassLibrary/");
-        cboProps.BaseProjectPublishOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/MyClassLibrary/");
-        cboProps.BaseProjectTestResultsOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/MyClassLibrary/");
-        cboProps.ProjectIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/MyClassLibrary/");
-        cboProps.ProjectOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/MyClassLibrary/");
-        cboProps.RelativeProjectPath.MakeRelative(this.ProjectOutput).ShouldBe("MyClassLibrary/");
-
-        CoverletProperties coverletProps = properties.Coverlet;
-        coverletProps.CoverletOutput.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/MyClassLibrary/");
-
-        CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
-        msbuildProps.BaseIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/MyClassLibrary/");
-        msbuildProps.BaseOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/MyClassLibrary/");
-
-        // The target framework is added after CentralBuildOutput sets it, which adds a / or \ to the end
-        // depending on the OS. This is the reason for the ToPosixPath in this case.
-        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ToPosixPath()
-            .ShouldBe("__output/Debug/MyClassLibrary/netstandard2.0/");
-
-        CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
-        msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/MyClassLibrary/");
-
-        MSBuildOtherProperties msBuildOtherProps = properties.MSBuildOther;
-        msBuildOtherProps.MSBuildProjectExtensionPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/MyClassLibrary/");
-
-        VSTestProperties vsTestProps = properties.VSTest;
-        vsTestProps.VSTestResultsDirectory.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/MyClassLibrary/");
-
-        File.Exists("__output/Debug/MyClassLibrary/netstandard2.0/MyClassLibrary.dll").ShouldBeTrue();
-        Directory.Exists("__intermediate/MyClassLibrary/Debug/netstandard2.0").ShouldBeTrue();
-    }
-
-    /// <summary>
-    /// Validates a traversal project:
-    ///     Directory.Build.props
-    ///     Directory.Build.targets
-    ///     nuget.config
-    ///     dirs.proj
-    /// </summary>
-    [Fact]
-    public void TraversalProject()
-    {
-        // Arrange
-        this.SetupDirectoryBuildProps();
-
-        // Act
-        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Create(
-            path: "dirs.proj",
-            sdk: "Microsoft.Build.Traversal/3.1.6"));
-
-        // Assert
-        Properties properties = Properties.Load(project);
-
-        CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
-        cboProps.RelativeProjectPath.ShouldBe("dirs/");
-
-        CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
-        msbuildProps.BaseIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/dirs/");
-
-        // The target framework is added after CentralBuildOutput sets it, which adds a / or \ to the end
-        // depending on the OS. This is the reason for the ToPosixPath in this case.
-        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ToPosixPath()
-            .ShouldBe("__output/Debug/dirs/net45/");
-
-        MSBuildOtherProperties msBuildOtherProps = properties.MSBuildOther;
-        msBuildOtherProps.MSBuildProjectExtensionPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/dirs/");
-
-        Directory.Exists("obj").ShouldBeFalse();
-        Directory.Exists("__intermediate/dirs").ShouldBeTrue();
-    }
-
-    /// <summary>
-    /// Validates a project built for a Debug build configuration:
-    ///     Directory.Build.props
-    ///     Directory.Build.targets
-    ///     nuget.config
-    ///     src/MyClassLibrary/MyClassLibrary.csproj
-    /// </summary>
-    [Fact]
-    public void WithBuildConfigurationDebug()
-    {
-        // Arrange
-        this.SetupDirectoryBuildProps();
-
-        // Act
-        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
-            .SdkCsproj(path: "src/MyClassLibrary/MyClassLibrary.csproj", globalProperties: new Dictionary<string, string>()
-            {
-                ["Configuration"] = "Debug"
-            }));
-
-        // Assert
-        Properties properties = Properties.Load(project);
-
-        CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
-        msbuildProps.Configuration.ShouldBe("Debug");
-        msbuildProps.BaseOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/src/MyClassLibrary/");
-
-        // The target framework is added after CentralBuildOutput sets it, which adds a / or \ to the end
-        // depending on the OS. This is the reason for the ToPosixPath in this case.
-        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ToPosixPath()
-            .ShouldBe("__output/Debug/src/MyClassLibrary/netstandard2.0/");
-
-        CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
-        cboProps.AppxPackageDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/src/MyClassLibrary/AppPackages/");
-        cboProps.BaseProjectPublishOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/src/MyClassLibrary/");
-        cboProps.DefaultArtifactsSource.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/Debug/");
-        cboProps.PackageOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/Debug/");
-        cboProps.ProjectOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/src/MyClassLibrary/");
-
-        CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
-        msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/src/MyClassLibrary/");
-
-        File.Exists("__output/Debug/src/MyClassLibrary/netstandard2.0/MyClassLibrary.dll").ShouldBeTrue();
-        Directory.Exists("__intermediate/src/MyClassLibrary/Debug/netstandard2.0").ShouldBeTrue();
-    }
-
-    /// <summary>
-    /// Validates a project built for a Release build configuration:
-    ///     Directory.Build.props
-    ///     Directory.Build.targets
-    ///     nuget.config
-    ///     src/MyClassLibrary/MyClassLibrary.csproj
-    /// </summary>
-    [Fact]
-    public void WithBuildConfigurationRelease()
-    {
-        // Arrange
-        this.SetupDirectoryBuildProps();
-
-        // Act
-        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
-            .SdkCsproj(path: "src/MyClassLibrary/MyClassLibrary.csproj", globalProperties: new Dictionary<string, string>()
-            {
-                ["Configuration"] = "Release"
-            }));
-
-        // Assert
-        Properties properties = Properties.Load(project);
-
-        CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
-        msbuildProps.Configuration.ShouldBe("Release");
-        msbuildProps.BaseOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Release/src/MyClassLibrary/");
-
-        // The target framework is added after CentralBuildOutput sets it, which adds a / or \ to the end
-        // depending on the OS. This is the reason for the ToPosixPath in this case.
-        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ToPosixPath()
-            .ShouldBe("__output/Release/src/MyClassLibrary/netstandard2.0/");
-
-        CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
-        cboProps.AppxPackageDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/Release/src/MyClassLibrary/AppPackages/");
-        cboProps.BaseProjectPublishOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Release/src/MyClassLibrary/");
-        cboProps.DefaultArtifactsSource.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/Release/");
-        cboProps.PackageOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/Release/");
-        cboProps.ProjectOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Release/src/MyClassLibrary/");
-
-        CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
-        msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Release/src/MyClassLibrary/");
-
-        File.Exists("__output/Release/src/MyClassLibrary/netstandard2.0/MyClassLibrary.dll").ShouldBeTrue();
-        Directory.Exists("__intermediate/src/MyClassLibrary/Release/netstandard2.0").ShouldBeTrue();
-    }
-
-    /// <summary>
-    /// Validates a project built specifying a build Platform of AnyCPU:
-    ///     Directory.Build.props
-    ///     Directory.Build.targets
-    ///     nuget.config
-    ///     src/MyClassLibrary/MyClassLibrary.csproj
-    /// </summary>
-    [Fact]
-    public void WithPlatformAnyCPU()
-    {
-        // Arrange
-        this.SetupDirectoryBuildProps();
-
-        // Act
-        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
-            .SdkCsproj(path: "src/MyClassLibrary/MyClassLibrary.csproj", globalProperties: new Dictionary<string, string>()
-            {
-                ["Platform"] = "AnyCPU"
-            }));
-
-        // Assert
-        Properties properties = Properties.Load(project);
-
-        CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
         cboProps.AppxPackageDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/src/MyClassLibrary/AppPackages/");
         cboProps.BaseIntDir.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/");
         cboProps.BaseNuGetDir.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/");
@@ -486,6 +104,386 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
 
         File.Exists("__output/Debug/AnyCPU/src/MyClassLibrary/netstandard2.0/MyClassLibrary.dll").ShouldBeTrue();
         Directory.Exists("__intermediate/src/MyClassLibrary/Debug/netstandard2.0").ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Validates a project in a project folder:
+    ///     Directory.Build.props
+    ///     Directory.Build.targets
+    ///     nuget.config
+    ///     src/MyClassLibrary/MyClassLibrary.csproj
+    /// </summary>
+    [Fact]
+    public void DefaultConfigurationWithMultiTargetting()
+    {
+        // Arrange
+        this.SetupDirectoryBuildProps();
+
+        // Act
+        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
+            .SdkCsproj(
+                path: "src/MyClassLibrary/MyClassLibrary.csproj",
+                targetFrameworks: new[] { "netstandard1.6", "netstandard2.0", "netstandard2.1" }));
+
+        // Assert
+        Properties properties = Properties.Load(project);
+
+        CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
+        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/src/MyClassLibrary/");
+
+        File.Exists("__output/Debug/AnyCPU/src/MyClassLibrary/netstandard1.6/MyClassLibrary.dll").ShouldBeTrue();
+        File.Exists("__output/Debug/AnyCPU/src/MyClassLibrary/netstandard2.0/MyClassLibrary.dll").ShouldBeTrue();
+        File.Exists("__output/Debug/AnyCPU/src/MyClassLibrary/netstandard2.1/MyClassLibrary.dll").ShouldBeTrue();
+        Directory.Exists("__intermediate/src/MyClassLibrary/Debug/netstandard1.6").ShouldBeTrue();
+        Directory.Exists("__intermediate/src/MyClassLibrary/Debug/netstandard2.0").ShouldBeTrue();
+        Directory.Exists("__intermediate/src/MyClassLibrary/Debug/netstandard2.1").ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Validates a project in a project folder, but with CentralBuildOutputFolderPrefix set to "_prefix_":
+    ///     Directory.Build.props
+    ///     Directory.Build.targets
+    ///     nuget.config
+    ///     src/MyClassLibrary/MyClassLibrary.csproj
+    /// </summary>
+    [Fact]
+    public void PrefixOverride()
+    {
+        // Arrange
+        this.SetupDirectoryBuildProps(
+            projectFunction: p => p.Property("CentralBuildOutputFolderPrefix", "_prefix_"));
+
+        // Act
+        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
+            .SdkCsproj(path: "src/MyClassLibrary/MyClassLibrary.csproj"));
+
+        // Assert
+        Properties properties = Properties.Load(project);
+
+        CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
+        cboProps.BaseIntDir.MakeRelative(this.ProjectOutput).ShouldBe("_prefix_intermediate/");
+        cboProps.BaseOutDir.MakeRelative(this.ProjectOutput).ShouldBe("_prefix_output/");
+        cboProps.BasePackagesDir.MakeRelative(this.ProjectOutput).ShouldBe("_prefix_packages/");
+        cboProps.BasePublishDir.MakeRelative(this.ProjectOutput).ShouldBe("_prefix_publish/");
+        cboProps.BaseTestResultsDir.MakeRelative(this.ProjectOutput).ShouldBe("_prefix_test-results/");
+        cboProps.CentralBuildOutputFolderPrefix.MakeRelative(this.ProjectOutput).ShouldBe("_prefix_");
+
+        File.Exists("_prefix_output/Debug/AnyCPU/src/MyClassLibrary/netstandard2.0/MyClassLibrary.dll").ShouldBeTrue();
+        Directory.Exists("_prefix_intermediate/src/MyClassLibrary/Debug/netstandard2.0").ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Validates a project in the root folder:
+    ///     Directory.Build.props
+    ///     Directory.Build.targets
+    ///     nuget.config
+    ///     MyClassLibrary.csproj
+    /// </summary>
+    [Fact]
+    public void ProjectInRoot()
+    {
+        // Arrange
+        this.SetupDirectoryBuildProps();
+
+        // Act
+        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
+            .SdkCsproj(path: Path.Combine(this.ProjectOutput, "MyClassLibrary.csproj")));
+
+        // Assert
+        Properties properties = Properties.Load(project);
+
+        CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
+        cboProps.AppxPackageDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/AppPackages/");
+        cboProps.BaseIntDir.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/");
+        cboProps.BaseNuGetDir.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/");
+        cboProps.BaseOutDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/");
+        cboProps.BasePackagesDir.MakeRelative(this.ProjectOutput).ShouldBe("__packages/");
+        cboProps.BaseProjectIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/");
+        cboProps.BaseProjectPublishOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/");
+        cboProps.BaseProjectTestResultsOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/");
+        cboProps.BasePublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/");
+        cboProps.BaseTestResultsDir.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/");
+        cboProps.CentralBuildOutputFolderPrefix.MakeRelative(this.ProjectOutput).ShouldBe("__");
+        cboProps.CentralBuildOutputPath.MakeRelative(this.ProjectOutput).ShouldBeEmpty();
+        cboProps.DefaultArtifactsSource.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/Debug/");
+        cboProps.EnableCentralBuildOutput.MakeRelative(this.ProjectOutput).ShouldBeEmpty();
+        cboProps.PackageOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/Debug/");
+        cboProps.ProjectIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/");
+        cboProps.ProjectOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/");
+        cboProps.RelativeProjectPath.MakeRelative(this.ProjectOutput).ShouldBeEmpty();
+
+        CoverletProperties coverletProps = properties.Coverlet;
+        coverletProps.CoverletOutput.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/");
+
+        CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
+        msbuildProps.BaseIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/");
+        msbuildProps.BaseOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/");
+
+        // The target framework is added after CentralBuildOutput sets it, which adds a / or \ to the end
+        // depending on the OS. This is the reason for the ToPosixPath in this case.
+        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ToPosixPath()
+            .ShouldBe("__output/Debug/AnyCPU/netstandard2.0/");
+
+        CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
+        msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/");
+
+        MSBuildOtherProperties msBuildOtherProps = properties.MSBuildOther;
+        msBuildOtherProps.MSBuildProjectExtensionPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/");
+
+        VSTestProperties vsTestProps = properties.VSTest;
+        vsTestProps.VSTestResultsDirectory.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/");
+    }
+
+    /// <summary>
+    /// Validates a project in a project folder, but with CentralBuildOutputRelativeToPath set to remove the src folder:
+    ///     Directory.Build.props
+    ///     Directory.Build.targets
+    ///     nuget.config
+    ///     src/MyClassLibrary/MyClassLibrary.csproj
+    /// </summary>
+    [Fact]
+    public void RelativePathOverride()
+    {
+        // Arrange
+        this.SetupDirectoryBuildProps(
+            projectFunction: p => p.Property("CentralBuildOutputRelativeToPath", Path.Combine(this.ProjectOutput, "src")));
+
+        // Act
+        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
+            .SdkCsproj(path: "src/MyClassLibrary/MyClassLibrary.csproj"));
+
+        // Assert
+        Properties properties = Properties.Load(project);
+
+        CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
+        cboProps.AppxPackageDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/MyClassLibrary/AppPackages/");
+        cboProps.BaseProjectIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/MyClassLibrary/");
+        cboProps.BaseProjectPublishOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/MyClassLibrary/");
+        cboProps.BaseProjectTestResultsOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/MyClassLibrary/");
+        cboProps.ProjectIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/MyClassLibrary/");
+        cboProps.ProjectOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/MyClassLibrary/");
+        cboProps.RelativeProjectPath.MakeRelative(this.ProjectOutput).ShouldBe("MyClassLibrary/");
+
+        CoverletProperties coverletProps = properties.Coverlet;
+        coverletProps.CoverletOutput.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/MyClassLibrary/");
+
+        CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
+        msbuildProps.BaseIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/MyClassLibrary/");
+        msbuildProps.BaseOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/MyClassLibrary/");
+
+        // The target framework is added after CentralBuildOutput sets it, which adds a / or \ to the end
+        // depending on the OS. This is the reason for the ToPosixPath in this case.
+        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ToPosixPath()
+            .ShouldBe("__output/Debug/AnyCPU/MyClassLibrary/netstandard2.0/");
+
+        CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
+        msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/MyClassLibrary/");
+
+        MSBuildOtherProperties msBuildOtherProps = properties.MSBuildOther;
+        msBuildOtherProps.MSBuildProjectExtensionPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/MyClassLibrary/");
+
+        VSTestProperties vsTestProps = properties.VSTest;
+        vsTestProps.VSTestResultsDirectory.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/MyClassLibrary/");
+
+        File.Exists("__output/Debug/AnyCPU/MyClassLibrary/netstandard2.0/MyClassLibrary.dll").ShouldBeTrue();
+        Directory.Exists("__intermediate/MyClassLibrary/Debug/netstandard2.0").ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Validates a traversal project:
+    ///     Directory.Build.props
+    ///     Directory.Build.targets
+    ///     nuget.config
+    ///     dirs.proj
+    /// </summary>
+    [Fact]
+    public void TraversalProject()
+    {
+        // Arrange
+        this.SetupDirectoryBuildProps();
+
+        // Act
+        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Create(
+            path: "dirs.proj",
+            sdk: "Microsoft.Build.Traversal/3.1.6"));
+
+        // Assert
+        Properties properties = Properties.Load(project);
+
+        CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
+        cboProps.RelativeProjectPath.ShouldBe("dirs/");
+
+        CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
+        msbuildProps.BaseIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/dirs/");
+
+        // The target framework is added after CentralBuildOutput sets it, which adds a / or \ to the end
+        // depending on the OS. This is the reason for the ToPosixPath in this case.
+        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ToPosixPath()
+            .ShouldBe("__output/Debug/AnyCPU/dirs/net45/");
+
+        MSBuildOtherProperties msBuildOtherProps = properties.MSBuildOther;
+        msBuildOtherProps.MSBuildProjectExtensionPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/dirs/");
+
+        Directory.Exists("obj").ShouldBeFalse();
+        Directory.Exists("__intermediate/dirs").ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Validates a project built for a Debug build configuration:
+    ///     Directory.Build.props
+    ///     Directory.Build.targets
+    ///     nuget.config
+    ///     src/MyClassLibrary/MyClassLibrary.csproj
+    /// </summary>
+    [Fact]
+    public void WithBuildConfigurationDebug()
+    {
+        // Arrange
+        this.SetupDirectoryBuildProps();
+
+        // Act
+        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
+            .SdkCsproj(path: "src/MyClassLibrary/MyClassLibrary.csproj", globalProperties: new Dictionary<string, string>()
+            {
+                ["Configuration"] = "Debug"
+            }));
+
+        // Assert
+        Properties properties = Properties.Load(project);
+
+        CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
+        msbuildProps.Configuration.ShouldBe("Debug");
+        msbuildProps.BaseOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/src/MyClassLibrary/");
+        // The target framework is added after CentralBuildOutput sets it, which adds a / or \ to the end
+        // depending on the OS. This is the reason for the ToPosixPath in this case.
+        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ToPosixPath()
+            .ShouldBe("__output/Debug/AnyCPU/src/MyClassLibrary/netstandard2.0/");
+
+        CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
+        cboProps.AppxPackageDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/src/MyClassLibrary/AppPackages/");
+        cboProps.BaseProjectPublishOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/src/MyClassLibrary/");
+        cboProps.DefaultArtifactsSource.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/Debug/");
+        cboProps.PackageOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/Debug/");
+        cboProps.ProjectOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/src/MyClassLibrary/");
+
+        CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
+        msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/src/MyClassLibrary/");
+
+        File.Exists("__output/Debug/AnyCPU/src/MyClassLibrary/netstandard2.0/MyClassLibrary.dll").ShouldBeTrue();
+        Directory.Exists("__intermediate/src/MyClassLibrary/Debug/netstandard2.0").ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Validates a project built for a Release build configuration:
+    ///     Directory.Build.props
+    ///     Directory.Build.targets
+    ///     nuget.config
+    ///     src/MyClassLibrary/MyClassLibrary.csproj
+    /// </summary>
+    [Fact]
+    public void WithBuildConfigurationRelease()
+    {
+        // Arrange
+        this.SetupDirectoryBuildProps();
+
+        // Act
+        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
+            .SdkCsproj(path: "src/MyClassLibrary/MyClassLibrary.csproj", globalProperties: new Dictionary<string, string>()
+            {
+                ["Configuration"] = "Release"
+            }));
+
+        // Assert
+        Properties properties = Properties.Load(project);
+
+        CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
+        msbuildProps.Configuration.ShouldBe("Release");
+        msbuildProps.BaseOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Release/AnyCPU/src/MyClassLibrary/");
+        // The target framework is added after CentralBuildOutput sets it, which adds a / or \ to the end
+        // depending on the OS. This is the reason for the ToPosixPath in this case.
+        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ToPosixPath()
+            .ShouldBe("__output/Release/AnyCPU/src/MyClassLibrary/netstandard2.0/");
+
+        CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
+        cboProps.AppxPackageDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/Release/AnyCPU/src/MyClassLibrary/AppPackages/");
+        cboProps.BaseProjectPublishOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Release/AnyCPU/src/MyClassLibrary/");
+        cboProps.DefaultArtifactsSource.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/Release/");
+        cboProps.PackageOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/Release/");
+        cboProps.ProjectOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Release/AnyCPU/src/MyClassLibrary/");
+
+        CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
+        msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Release/AnyCPU/src/MyClassLibrary/");
+
+        File.Exists("__output/Release/AnyCPU/src/MyClassLibrary/netstandard2.0/MyClassLibrary.dll").ShouldBeTrue();
+        Directory.Exists("__intermediate/src/MyClassLibrary/Release/netstandard2.0").ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Validates a project built specifying a build Platform of x64:
+    ///     Directory.Build.props
+    ///     Directory.Build.targets
+    ///     nuget.config
+    ///     src/MyClassLibrary/MyClassLibrary.csproj
+    /// </summary>
+    [Fact]
+    public void WithPlatformX64()
+    {
+        // Arrange
+        this.SetupDirectoryBuildProps();
+
+        // Act
+        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
+            .SdkCsproj(path: "src/MyClassLibrary/MyClassLibrary.csproj", globalProperties: new Dictionary<string, string>()
+            {
+                ["Platform"] = "x64"
+            }));
+
+        // Assert
+        Properties properties = Properties.Load(project);
+
+        CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
+        cboProps.AppxPackageDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/x64/src/MyClassLibrary/AppPackages/");
+        cboProps.BaseIntDir.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/");
+        cboProps.BaseNuGetDir.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/");
+        cboProps.BaseOutDir.MakeRelative(this.ProjectOutput).ShouldBe("__output/");
+        cboProps.BasePackagesDir.MakeRelative(this.ProjectOutput).ShouldBe("__packages/");
+        cboProps.BaseProjectIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/src/MyClassLibrary/");
+        cboProps.BaseProjectPublishOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/x64/src/MyClassLibrary/");
+        cboProps.BaseProjectTestResultsOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/src/MyClassLibrary/");
+        cboProps.BasePublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/");
+        cboProps.BaseTestResultsDir.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/");
+        cboProps.CentralBuildOutputFolderPrefix.MakeRelative(this.ProjectOutput).ShouldBe("__");
+        cboProps.CentralBuildOutputPath.MakeRelative(this.ProjectOutput).ShouldBeEmpty();
+        cboProps.DefaultArtifactsSource.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/Debug/");
+        cboProps.EnableCentralBuildOutput.MakeRelative(this.ProjectOutput).ShouldBeEmpty();
+        cboProps.PackageOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__packages/NuGet/Debug/");
+        cboProps.ProjectIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/src/MyClassLibrary/");
+        cboProps.ProjectOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/x64/src/MyClassLibrary/");
+        cboProps.RelativeProjectPath.MakeRelative(this.ProjectOutput).ShouldBe("src/MyClassLibrary/");
+
+        CoverletProperties coverletProps = properties.Coverlet;
+        coverletProps.CoverletOutput.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/src/MyClassLibrary/");
+
+        CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
+        msbuildProps.BaseIntermediateOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/src/MyClassLibrary/");
+        msbuildProps.BaseOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/x64/src/MyClassLibrary/");
+
+        // The target framework is added after CentralBuildOutput sets it, which adds a / or \ to the end
+        // depending on the OS. This is the reason for the ToPosixPath in this case.
+        msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ToPosixPath()
+            .ShouldBe("__output/Debug/x64/src/MyClassLibrary/netstandard2.0/");
+
+        CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
+        msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/x64/src/MyClassLibrary/");
+
+        MSBuildOtherProperties msBuildOtherProps = properties.MSBuildOther;
+        msBuildOtherProps.MSBuildProjectExtensionPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/src/MyClassLibrary/");
+
+        VSTestProperties vsTestProps = properties.VSTest;
+        vsTestProps.VSTestResultsDirectory.MakeRelative(this.ProjectOutput).ShouldBe("__test-results/src/MyClassLibrary/");
+
+        File.Exists("__output/Debug/x64/src/MyClassLibrary/netstandard2.0/MyClassLibrary.dll").ShouldBeTrue();
+        Directory.Exists("__intermediate/src/MyClassLibrary/x64/Debug/netstandard2.0").ShouldBeTrue();
     }
 
     private ProjectCreator CreateSaveAndBuildProject(Func<ProjectCreator> projectFunction)

--- a/src/CentralBuildOutput.Tests/Extensions/ProjectCreatorTemplatesExtensions.cs
+++ b/src/CentralBuildOutput.Tests/Extensions/ProjectCreatorTemplatesExtensions.cs
@@ -12,9 +12,7 @@ internal static class ProjectCreatorTemplatesExtensions
         Action<ProjectCreator>? projectFunction = null)
     {
         ProjectCreator result = ProjectCreator.Create()
-            .Property("CentralBuildOutputPath", centralBuidOutputPath)
-            .Property("Configuration", "Debug", setIfEmpty: true)
-            .Property("Platform", "AnyCPU", setIfEmpty: true);
+            .Property("CentralBuildOutputPath", centralBuidOutputPath);
 
         if (projectFunction is not null)
         {

--- a/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
+++ b/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
@@ -71,8 +71,16 @@
     <BasePublishDir>$(CentralBuildOutputPath)$(CentralBuildOutputFolderPrefix)publish/</BasePublishDir>
     <BaseTestResultsDir>$(CentralBuildOutputPath)$(CentralBuildOutputFolderPrefix)test-results/</BaseTestResultsDir>
 
+    <!-- Configure configuration and platform paths. -->
+    <CentralBuildOutputConfiguration Condition=" '$(Configuration)' == '' ">Debug</CentralBuildOutputConfiguration>
+    <CentralBuildOutputConfiguration Condition=" '$(Configuration)' != '' ">$(Configuration)</CentralBuildOutputConfiguration>
+    <CentralBuildOutputConfigurationPath>$(CentralBuildOutputConfiguration)/</CentralBuildOutputConfigurationPath>
+    <CentralBuildOutputPlatform Condition=" '$(Platform)' != '' ">$(Platform)</CentralBuildOutputPlatform>
+    <CentralBuildOutputPlatformPath Condition=" '$(CentralBuildOutputPlatform)' != '' ">$(CentralBuildOutputPlatform)/</CentralBuildOutputPlatformPath>
+    <CentralBuildOutputConfigurationPlatformPath>$(CentralBuildOutputConfigurationPath)$(CentralBuildOutputPlatformPath)</CentralBuildOutputConfigurationPlatformPath>
+
     <!-- Configure NuGet output folder. -->
-    <PackageOutputPath>$(BaseNuGetDir)$(Configuration)/</PackageOutputPath>
+    <PackageOutputPath>$(BaseNuGetDir)$(CentralBuildOutputConfigurationPath)</PackageOutputPath>
 
     <!--
       Since we're moving the package output path, we need to inform Microsoft.Build.Artifacts where to pick up the
@@ -81,13 +89,13 @@
     <DefaultArtifactsSource>$(PackageOutputPath)</DefaultArtifactsSource>
 
     <!-- Configure project specific intermediate and output folders. -->
-    <ProjectOutputPath>$(BaseOutDir)$(Configuration)/$(Platform)/$(RelativeProjectPath)</ProjectOutputPath>
+    <ProjectOutputPath>$(BaseOutDir)$(CentralBuildOutputConfigurationPlatformPath)$(RelativeProjectPath)</ProjectOutputPath>
 
     <!-- Configure Appx output path. -->
     <AppxPackageDir>$(ProjectOutputPath)AppPackages/</AppxPackageDir>
 
     <BaseProjectIntermediateOutputPath>$(BaseIntDir)$(RelativeProjectPath)</BaseProjectIntermediateOutputPath>
-    <BaseProjectPublishOutputPath>$(BasePublishDir)$(Configuration)/$(Platform)/$(RelativeProjectPath)</BaseProjectPublishOutputPath>
+    <BaseProjectPublishOutputPath>$(BasePublishDir)$(CentralBuildOutputConfigurationPlatformPath)$(RelativeProjectPath)</BaseProjectPublishOutputPath>
     <BaseProjectTestResultsOutputPath>$(BaseTestResultsDir)$(RelativeProjectPath)</BaseProjectTestResultsOutputPath>
   </PropertyGroup>
 

--- a/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
+++ b/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
@@ -75,7 +75,7 @@
     <CentralBuildOutputConfiguration Condition=" '$(Configuration)' == '' ">Debug</CentralBuildOutputConfiguration>
     <CentralBuildOutputConfiguration Condition=" '$(Configuration)' != '' ">$(Configuration)</CentralBuildOutputConfiguration>
     <CentralBuildOutputConfigurationPath>$(CentralBuildOutputConfiguration)/</CentralBuildOutputConfigurationPath>
-    <CentralBuildOutputPlatform Condition=" '$(Platform)' == '' ">AnyCPU</CentralBuildOutputPlatform>
+    <CentralBuildOutputPlatform Condition=" '$(Platform)' == '' and '$(CentralBuildOutputNoDefaultPlatform)' != 'true' ">AnyCPU</CentralBuildOutputPlatform>
     <CentralBuildOutputPlatform Condition=" '$(Platform)' != '' ">$(Platform)</CentralBuildOutputPlatform>
     <CentralBuildOutputPlatformPath Condition=" '$(CentralBuildOutputPlatform)' != '' ">$(CentralBuildOutputPlatform)/</CentralBuildOutputPlatformPath>
     <CentralBuildOutputConfigurationPlatformPath>$(CentralBuildOutputConfigurationPath)$(CentralBuildOutputPlatformPath)</CentralBuildOutputConfigurationPlatformPath>

--- a/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
+++ b/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
@@ -75,6 +75,7 @@
     <CentralBuildOutputConfiguration Condition=" '$(Configuration)' == '' ">Debug</CentralBuildOutputConfiguration>
     <CentralBuildOutputConfiguration Condition=" '$(Configuration)' != '' ">$(Configuration)</CentralBuildOutputConfiguration>
     <CentralBuildOutputConfigurationPath>$(CentralBuildOutputConfiguration)/</CentralBuildOutputConfigurationPath>
+    <CentralBuildOutputPlatform Condition=" '$(Platform)' == '' ">AnyCPU</CentralBuildOutputPlatform>
     <CentralBuildOutputPlatform Condition=" '$(Platform)' != '' ">$(Platform)</CentralBuildOutputPlatform>
     <CentralBuildOutputPlatformPath Condition=" '$(CentralBuildOutputPlatform)' != '' ">$(CentralBuildOutputPlatform)/</CentralBuildOutputPlatformPath>
     <CentralBuildOutputConfigurationPlatformPath>$(CentralBuildOutputConfigurationPath)$(CentralBuildOutputPlatformPath)</CentralBuildOutputConfigurationPlatformPath>


### PR DESCRIPTION
Rather than requiring customers to set a default configuration and platform to get output to be consistent, I've defaulted them to Debug and AnyCPU respectively. As an option, you can set `CentralBuildOutputNoDefaultPlatform` to `true` to allow omitting the platform in the output in the case of the default `AnyCPU` platform.