### PR TITLE
Ensure CentralBuildOutputPath has a trailing slash

### DIFF
--- a/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
@@ -14,6 +14,31 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
     }
 
     /// <summary>
+    /// Validates a project with CentralBuildOutput missing a trailing slash:
+    ///     Directory.Build.props
+    ///     Directory.Build.targets
+    ///     nuget.config
+    ///     src/MyClassLibrary/MyClassLibrary.csproj
+    /// </summary>
+    [Fact]
+    public void CentralBuildOutputMissingTrailingSlash()
+    {
+        // Arrange
+        this.SetupDirectoryBuildProps("$(MSBuildThisFileDirectory.TrimEnd('/').TrimEnd('\\'))");
+
+        // Act
+        ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
+            .SdkCsproj(path: "src/MyClassLibrary/MyClassLibrary.csproj"));
+
+        // Assert
+        Properties properties = Properties.Load(project);
+
+        CentralBuildOutputProperties cboProps = properties.CentralBuildOutput;
+        cboProps.CentralBuildOutputPath.MakeRelative(this.ProjectOutput).ShouldBeEmpty();
+        cboProps.CentralBuildOutputPath.ShouldEndWith(Path.DirectorySeparatorChar.ToString());
+    }
+
+    /// <summary>
     /// Validates that the CentralBuildOutputPath must be set.
     ///     Directory.Build.props
     ///     Directory.Build.targets

--- a/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
+++ b/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
@@ -38,6 +38,9 @@
     <!-- Allow the user to override the folder prefix. Defaults to '__' -->
     <CentralBuildOutputFolderPrefix Condition=" '$(CentralBuildOutputFolderPrefix)' == '' ">__</CentralBuildOutputFolderPrefix>
 
+    <!-- Ensure that CentralBuildOutputPath ends with a trailing slash. -->
+    <CentralBuildOutputPath>$([MSBuild]::EnsureTrailingSlash('$(CentralBuildOutputPath)'))</CentralBuildOutputPath>
+
     <RelativeProjectPath>$([MSBuild]::MakeRelative($(CentralBuildOutputPath), $(MSBuildProjectDirectory)))/</RelativeProjectPath>
 
     <!--


### PR DESCRIPTION
  - This change ensure that `CentralBuildOutputPath` has a trailing slash if the user doesn't provide one.