### PR TITLE
Added some path manipulation features

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Setting the following properties controls how Central Build Output works.
 | Property                                | Description                                                                                          |
 | ---                                     | ---                                                                                                  |
 | `CentralBuildOutputPath` (Required)     | Defines the output path of the build output folders.                                                 |
+| `CentralBuildOutputConfigPlatLast`      | Places the configuration and platform at the end of the path if set to `true`.                       |
 | `CentralBuildOutputFolderPrefix`        | Overrides the output folder prefix. Default is `__`.                                                 |
 | `CentralBuildOutputNoDefaultPlatform`   | Omits the default platform name in the output path unless necessary if set to `true`.                |
 | `CentralBuildOutputRelativeToPath`      | Redefines the root folder used to calculate the relative folder used in build output folders.        |

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Setting the following properties controls how Central Build Output works.
 | `CentralBuildOutputConfigPlatLast`      | Places the configuration and platform at the end of the path if set to `true`.                       |
 | `CentralBuildOutputFolderPrefix`        | Overrides the output folder prefix. Default is `__`.                                                 |
 | `CentralBuildOutputNoDefaultPlatform`   | Omits the default platform name in the output path unless necessary if set to `true`.                |
+| `CentralBuildOutputNoPlatform`          | Omits the platform from the output path if set to `true`.                                            |
 | `CentralBuildOutputRelativeToPath`      | Redefines the root folder used to calculate the relative folder used in build output folders.        |
 | `CustomBeforeCentralBuildOutputProps`   | A list of custom MSBuild projects to import **before** central build output properties are declared. |
 | `CustomAfterCentralBuildOutputProps`    | A list of custom MSBuild projects to import **after** central build output properties are declared.  |

--- a/src/CentralBuildOutput.Tests/Extensions/StringExtensions.cs
+++ b/src/CentralBuildOutput.Tests/Extensions/StringExtensions.cs
@@ -8,6 +8,11 @@ internal static class StringExtensions
 
     public static string MakeRelative(this string path, string rootPath)
     {
+        if (!Path.IsPathFullyQualified(path))
+        {
+            throw new ArgumentException($"The path is not fully qualified: {path}.", nameof(path));
+        }
+
         string result = path;
 
         if (path.StartsWith(rootPath, StringComparison.Ordinal))

--- a/src/CentralBuildOutput.Tests/MSBuild/CentralBuildOutputProperties.cs
+++ b/src/CentralBuildOutput.Tests/MSBuild/CentralBuildOutputProperties.cs
@@ -35,6 +35,11 @@ internal class CentralBuildOutputProperties
     public string BaseProjectIntermediateOutputPath { get; init; } = string.Empty;
 
     /// <summary>
+    /// The base project output path.
+    /// </summary>
+    public string BaseProjectOutputPath { get; init; } = string.Empty;
+
+    /// <summary>
     /// The base project publish output path.
     /// </summary>
     public string BaseProjectPublishOutputPath { get; init; } = string.Empty;
@@ -106,6 +111,7 @@ internal class CentralBuildOutputProperties
         creator.TryGetPropertyValue(nameof(BaseOutDir), out string baseOutDir);
         creator.TryGetPropertyValue(nameof(BasePackagesDir), out string basePackagesDir);
         creator.TryGetPropertyValue(nameof(BaseProjectIntermediateOutputPath), out string baseProjectIntermediateOutputPath);
+        creator.TryGetPropertyValue(nameof(BaseProjectOutputPath), out string baseProjectOutputPath);
         creator.TryGetPropertyValue(nameof(BaseProjectPublishOutputPath), out string baseProjectPublishOutputPath);
         creator.TryGetPropertyValue(nameof(BaseProjectTestResultsOutputPath), out string baseProjectTestResultsOutputPath);
         creator.TryGetPropertyValue(nameof(BasePublishDir), out string basePublishDir);
@@ -127,6 +133,7 @@ internal class CentralBuildOutputProperties
             BaseOutDir = baseOutDir,
             BasePackagesDir = basePackagesDir,
             BaseProjectIntermediateOutputPath = baseProjectIntermediateOutputPath,
+            BaseProjectOutputPath = baseProjectOutputPath,
             BaseProjectPublishOutputPath = baseProjectPublishOutputPath,
             BaseProjectTestResultsOutputPath = baseProjectTestResultsOutputPath,
             BasePublishDir = basePublishDir,

--- a/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
+++ b/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
@@ -92,15 +92,19 @@
     -->
     <DefaultArtifactsSource>$(PackageOutputPath)</DefaultArtifactsSource>
 
-    <!-- Configure project specific intermediate and output folders. -->
-    <ProjectOutputPath>$(BaseOutDir)$(CentralBuildOutputConfigurationPlatformPath)$(RelativeProjectPath)</ProjectOutputPath>
+    <!--
+      Configure project specific intermediate and output folders.
+      CentralBuildOutputConfigPlatLast allows users to move the configuration\platform to the end of the path.
+    -->
+    <ProjectOutputPath Condition=" '$(CentralBuildOutputConfigPlatLast)' != 'true' ">$(CentralBuildOutputConfigurationPlatformPath)$(RelativeProjectPath)</ProjectOutputPath>
+    <ProjectOutputPath Condition=" '$(CentralBuildOutputConfigPlatLast)' == 'true' ">$(RelativeProjectPath)$(CentralBuildOutputConfigurationPlatformPath)</ProjectOutputPath>
+    <BaseProjectOutputPath>$(BaseOutDir)$(ProjectOutputPath)</BaseProjectOutputPath>
+    <BaseProjectIntermediateOutputPath>$(BaseIntDir)$(RelativeProjectPath)</BaseProjectIntermediateOutputPath>
+    <BaseProjectPublishOutputPath>$(BasePublishDir)$(ProjectOutputPath)</BaseProjectPublishOutputPath>
+    <BaseProjectTestResultsOutputPath>$(BaseTestResultsDir)$(RelativeProjectPath)</BaseProjectTestResultsOutputPath>
 
     <!-- Configure Appx output path. -->
-    <AppxPackageDir>$(ProjectOutputPath)AppPackages/</AppxPackageDir>
-
-    <BaseProjectIntermediateOutputPath>$(BaseIntDir)$(RelativeProjectPath)</BaseProjectIntermediateOutputPath>
-    <BaseProjectPublishOutputPath>$(BasePublishDir)$(CentralBuildOutputConfigurationPlatformPath)$(RelativeProjectPath)</BaseProjectPublishOutputPath>
-    <BaseProjectTestResultsOutputPath>$(BaseTestResultsDir)$(RelativeProjectPath)</BaseProjectTestResultsOutputPath>
+    <AppxPackageDir>$(BaseProjectOutputPath)AppPackages/</AppxPackageDir>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(CentralBuildOutputEnabledAndReady)' == 'true' ">
@@ -117,8 +121,8 @@
 
     <BaseIntermediateOutputPath>$(ProjectIntermediateOutputPath)</BaseIntermediateOutputPath>
     <MSBuildProjectExtensionPath>$(BaseIntermediateOutputPath)</MSBuildProjectExtensionPath>
-    <BaseOutputPath>$(ProjectOutputPath)</BaseOutputPath>
-    <OutputPath>$(ProjectOutputPath)</OutputPath>
+    <BaseOutputPath>$(BaseProjectOutputPath)</BaseOutputPath>
+    <OutputPath>$(BaseProjectOutputPath)</OutputPath>
     <PublishDir>$(BaseProjectPublishOutputPath)</PublishDir>
     <VSTestResultsDirectory>$(BaseProjectTestResultsOutputPath)</VSTestResultsDirectory>
     <CoverletOutput>$(BaseProjectTestResultsOutputPath)</CoverletOutput>
@@ -130,7 +134,7 @@
   <PropertyGroup Condition=" '$(CentralBuildOutputTraversalProject)' == 'true' ">
     <BaseIntermediateOutputPath>$(BaseProjectIntermediateOutputPath)</BaseIntermediateOutputPath>
     <MSBuildProjectExtensionPath>$(BaseProjectIntermediateOutputPath)</MSBuildProjectExtensionPath>
-    <OutputPath>$(ProjectOutputPath)</OutputPath>
+    <OutputPath>$(BaseProjectOutputPath)</OutputPath>
   </PropertyGroup>
 
 </Project>

--- a/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
+++ b/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
@@ -74,12 +74,17 @@
     <BasePublishDir>$(CentralBuildOutputPath)$(CentralBuildOutputFolderPrefix)publish/</BasePublishDir>
     <BaseTestResultsDir>$(CentralBuildOutputPath)$(CentralBuildOutputFolderPrefix)test-results/</BaseTestResultsDir>
 
-    <!-- Configure configuration and platform paths. -->
+    <!--
+      Configure configuration and platform paths.
+      CentralBuildOutputNoDefaultPlatform omits the platform portion of the path unless necessary.
+      CentralBuildOutputNoPlatform omits the platform portion of the path completely.
+      -->
     <CentralBuildOutputConfiguration Condition=" '$(Configuration)' == '' ">Debug</CentralBuildOutputConfiguration>
     <CentralBuildOutputConfiguration Condition=" '$(Configuration)' != '' ">$(Configuration)</CentralBuildOutputConfiguration>
     <CentralBuildOutputConfigurationPath>$(CentralBuildOutputConfiguration)/</CentralBuildOutputConfigurationPath>
     <CentralBuildOutputPlatform Condition=" '$(Platform)' == '' and '$(CentralBuildOutputNoDefaultPlatform)' != 'true' ">AnyCPU</CentralBuildOutputPlatform>
     <CentralBuildOutputPlatform Condition=" '$(Platform)' != '' ">$(Platform)</CentralBuildOutputPlatform>
+    <CentralBuildOutputPlatform Condition=" '$(CentralBuildOutputNoPlatform)' == 'true' "></CentralBuildOutputPlatform>
     <CentralBuildOutputPlatformPath Condition=" '$(CentralBuildOutputPlatform)' != '' ">$(CentralBuildOutputPlatform)/</CentralBuildOutputPlatformPath>
     <CentralBuildOutputConfigurationPlatformPath>$(CentralBuildOutputConfigurationPath)$(CentralBuildOutputPlatformPath)</CentralBuildOutputConfigurationPlatformPath>
 


### PR DESCRIPTION
- Added CentralBuildOutputConfigPlatLast
  - This change adds a new feature to place the configuration and platform pair last in the path by settings `CentralBuildOutputConfigPlatLast` to `true`.
- Added CentralBuildOutputNoPlatform
  - This change adds the ability to omit the platform from the path entirely by setting `CentralBuildOutputNoPlatform` to `true`.