### PR TITLE
Lock build to .NET 6 SDK 6.0.203 and remove .NET 5 from test platforms

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,11 +34,6 @@ jobs:
         with:
           dotnet-version: 3.1.x
 
-      - name: Setup .NET 5.x SDK
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 5.x
-
       - name: Setup .NET 6.x SDK
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           dotnet-version: 3.1.x
 
-      - name: Setup .NET 6.x SDK
+      - name: Setup .NET 6.0.203 SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.x
+          dotnet-version: 6.0.203
 
       - name: Install dependencies
         run: dotnet restore

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -26,11 +26,6 @@ jobs:
         with:
           dotnet-version: 3.1.x
 
-      - name: Setup .NET 5.x SDK
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 5.x
-
       - name: Setup .NET 6.x SDK
         uses: actions/setup-dotnet@v1
         with:

--- a/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>Treasure.Build.CentralBuildOutput.Tests</AssemblyName>
     <RootNamespace>Treasure.Build.CentralBuildOutput.Tests</RootNamespace>


### PR DESCRIPTION
  - I seem to be encountering an issue with newer .NET 6 SDKs (likely the runtime actually) related to the use of MSBuild.ProjectCreation (https://github.com/jeffkl/MSBuildProjectCreator/issues/170) which is preventing me from being able to build. This serves as a workaround for now.
  - This change removes .NET 5 from the test platforms since it is now [End of Support](https://dotnet.microsoft.com/download/dotnet) as of May 10, 2022.