### PR TITLE
Use `dotnet format`

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,12 +2,6 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "dotnet-format": {
-      "version": "6.3.315103",
-      "commands": [
-        "dotnet-format"
-      ]
-    },
     "nbgv": {
       "version": "3.4.255",
       "commands": [

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
           Write-Host "::set-output name=package_version::$packageVersion"
 
       - name: DotNet Format
-        run: dotnet dotnet-format --no-restore --verify-no-changes
+        run: dotnet format --no-restore --verify-no-changes
 
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -34,11 +34,8 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
-      - name: Install .NET tools
-        run: dotnet tool restore
-
       - name: DotNet Format
-        run: dotnet dotnet-format --no-restore --verify-no-changes
+        run: dotnet format --no-restore --verify-no-changes
 
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/nuget.config
+++ b/nuget.config
@@ -3,14 +3,5 @@
   <packageSources>
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
   </packageSources>
-  <packageSourceMapping>
-    <packageSource key="nuget">
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet6">
-      <package pattern="dotnet-format" />
-    </packageSource>
-  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
  - Now that `dotnet format` has been fixed in recent .NET 6 SDK versions, we can switch back to the built-in `format` command over the `dotnet-format` tool.