### PR TITLE
Update dependencies and fix MSBuild.ProjectCreation issues

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,10 +34,10 @@ jobs:
         with:
           dotnet-version: 3.1.x
 
-      - name: Setup .NET 6.0.203 SDK
+      - name: Setup .NET 6.x SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.203
+          dotnet-version: 6.x
 
       - name: Install dependencies
         run: dotnet restore

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           dotnet-version: 3.1.x
 
-      - name: Setup .NET 6.0.203 SDK
+      - name: Setup .NET 6.x SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.203
+          dotnet-version: 6.x
 
       - name: Install dependencies
         run: dotnet restore

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.201",
+    "version": "6.0.301",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   },

--- a/packages.props
+++ b/packages.props
@@ -18,6 +18,12 @@
     <PackageReference Update="Microsoft.NET.Test.Sdk"                           Version="17.2.0" />
     <PackageReference Update="Mono.Posix.NETStandard"                           Version="1.0.0" />
     <PackageReference Update="MSBuild.ProjectCreation"                          Version="8.0.0" />
+    <!-- Transitive update to workaround
+      https://github.com/jeffkl/MSBuildProjectCreator/issues/170
+    -->
+    <PackageReference Update="NuGet.Frameworks"                                 Version="6.2.1" />
+    <PackageReference Update="NuGet.Frameworks"                                 Version="5.11.2"
+                      Condition=" '$(TargetFramework)' == 'netcoreapp3.1' " />
     <PackageReference Update="Shouldly"                                         Version="4.0.3" />
     <PackageReference Update="xunit"                                            Version="2.4.1" />
     <PackageReference Update="xunit.runner.visualstudio"                        Version="2.4.5"

--- a/packages.props
+++ b/packages.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
-    <GlobalPackageReference Include="Nerdbank.GitVersioning"                    Version="3.4.255"
+    <GlobalPackageReference Include="Nerdbank.GitVersioning"                    Version="3.5.107"
                             PrivateAssets="all"
                             Condition=" '$(EnableGitVersioning)' != 'false' " />
     <GlobalPackageReference Include="Microsoft.Build.Artifacts"                 Version="4.0.4"
@@ -15,12 +15,12 @@
     <PackageReference Update="IsExternalInit"                                   Version="1.0.2"
                       IncludeAssets="runtime; build; native; contentfiles; analyzers"
                       PrivateAssets="all" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk"                           Version="17.1.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk"                           Version="17.2.0" />
     <PackageReference Update="Mono.Posix.NETStandard"                           Version="1.0.0" />
     <PackageReference Update="MSBuild.ProjectCreation"                          Version="8.0.0" />
     <PackageReference Update="Shouldly"                                         Version="4.0.3" />
     <PackageReference Update="xunit"                                            Version="2.4.1" />
-    <PackageReference Update="xunit.runner.visualstudio"                        Version="2.4.3"
+    <PackageReference Update="xunit.runner.visualstudio"                        Version="2.4.5"
                       IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive"
                       PrivateAssets="all" />
   </ItemGroup>

--- a/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
@@ -11,6 +11,12 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Mono.Posix.NETStandard" />
     <PackageReference Include="MSBuild.ProjectCreation" />
+    <!-- Transitive update to workaround
+      https://github.com/jeffkl/MSBuildProjectCreator/issues/170
+    -->
+    <PackageReference Include="NuGet.Frameworks">
+      <ExcludeAsset>Compile</ExcludeAsset>
+    </PackageReference>
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />


### PR DESCRIPTION
  - Updated a few dependencies.
  - Applying a transitive update for NuGet.Frameworks to workaround https://github.com/jeffkl/MSBuildProjectCreator/issues/170.
  - Removing .NET 6 SDK fixed version workaround.