### PR TITLE
Update MSBuild.ProjectCreation

### DIFF
--- a/packages.props
+++ b/packages.props
@@ -17,13 +17,7 @@
                       PrivateAssets="all" />
     <PackageReference Update="Microsoft.NET.Test.Sdk"                           Version="17.2.0" />
     <PackageReference Update="Mono.Posix.NETStandard"                           Version="1.0.0" />
-    <PackageReference Update="MSBuild.ProjectCreation"                          Version="8.0.0" />
-    <!-- Transitive update to workaround
-      https://github.com/jeffkl/MSBuildProjectCreator/issues/170
-    -->
-    <PackageReference Update="NuGet.Frameworks"                                 Version="6.2.1" />
-    <PackageReference Update="NuGet.Frameworks"                                 Version="5.11.2"
-                      Condition=" '$(TargetFramework)' == 'netcoreapp3.1' " />
+    <PackageReference Update="MSBuild.ProjectCreation"                          Version="8.2.1" />
     <PackageReference Update="Shouldly"                                         Version="4.0.3" />
     <PackageReference Update="xunit"                                            Version="2.4.1" />
     <PackageReference Update="xunit.runner.visualstudio"                        Version="2.4.5"

--- a/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
@@ -11,12 +11,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Mono.Posix.NETStandard" />
     <PackageReference Include="MSBuild.ProjectCreation" />
-    <!-- Transitive update to workaround
-      https://github.com/jeffkl/MSBuildProjectCreator/issues/170
-    -->
-    <PackageReference Include="NuGet.Frameworks">
-      <ExcludeAsset>Compile</ExcludeAsset>
-    </PackageReference>
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />


### PR DESCRIPTION
  - Updating MSBuild.ProjectCreation to the latest, which allows me to get rid of the NuGet.Frameworks transitive dependency.