### PR TITLE
Fix NuGet.Frameworks.dll test issues in net6.0

### DIFF
--- a/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
@@ -28,4 +28,13 @@
     <None Include="..\CentralBuildOutput\Sdk\*" Link="Sdk\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <!--
+    A hack to use the .NET SDKs version of NuGet.Frameworks.dll, since it has a newer version than what is publicly available.
+  -->
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <Copy SourceFiles="$(MSBuildSDKsPath)\..\NuGet.Frameworks.dll"
+          DestinationFolder="$(OutputPath)"
+          ContinueOnError="false" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
  - The .NET 6 SDK has taken a dependency on a newer version of NuGet.Frameworks (6.2.1.7) than what is publicly available (6.2.1.2). This hack copies the SDK's version into the build output, which "fixes" the problem. For now...