### PR TITLE
Fix an issue building in Visual Studio

### DIFF
--- a/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
@@ -30,8 +30,10 @@
 
   <!--
     A hack to use the .NET SDKs version of NuGet.Frameworks.dll, since it has a newer version than what is publicly available.
+
+    This is not applicable when building from within Visual Studio.
   -->
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition=" '$(TargetFramework)' == 'net6.0' ">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition=" '$(BuildingInsideVisualStudio)' != 'true' and '$(TargetFramework)' == 'net6.0' ">
     <Copy SourceFiles="$(MSBuildSDKsPath)\..\NuGet.Frameworks.dll"
           DestinationFolder="$(OutputPath)"
           ContinueOnError="false" />


### PR DESCRIPTION
  - Previously, I applied a workaround for quirks with the NuGet.Frameworks.dll that prevented the test project from working. However, it appears that Visual Studio isn't affected (at least not 17.3.5) while the .NET CLI can be. However, the Visual Studio path define by `MSBuildSDKsPath` doesn't contain `NuGet.Frameworks.dll`, so i'm opting Visual Studio out of the workaround.