### PR TITLE
Partition by the RuntimeIdentifier when specified

### DIFF
--- a/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
+++ b/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
@@ -108,6 +108,9 @@
     <BaseProjectPublishOutputPath>$(BasePublishDir)$(ProjectOutputPath)</BaseProjectPublishOutputPath>
     <BaseProjectTestResultsOutputPath>$(BaseTestResultsDir)$(RelativeProjectPath)</BaseProjectTestResultsOutputPath>
 
+    <!-- If a RuntimeIdentifier is specified, we should append it to the publish output path. -->
+    <BaseProjectPublishOutputPath Condition=" '$(RuntimeIdentifier)' != '' and '$(_UsingDefaultRuntimeIdentifier)' != 'true' ">$(BaseProjectPublishOutputPath)$(RuntimeIdentifier)/</BaseProjectPublishOutputPath>
+
     <!-- Configure Appx output path. -->
     <AppxPackageDir>$(BaseProjectOutputPath)AppPackages/</AppxPackageDir>
   </PropertyGroup>


### PR DESCRIPTION
  - This change partitions the output by the `RuntimeIdentifier` when necessary. Fixes #52.