### PR TITLE
Define the NativeOutputPath property for Native AOT projects

### DIFF
--- a/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
@@ -49,7 +49,7 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
     public void CentralBuildOutputPathMustBeSet()
     {
         // Arrange
-        this.SetupDirectoryBuildProps(centralBuidOutputPath: string.Empty);
+        this.SetupDirectoryBuildProps(centralBuildOutputPath: string.Empty);
 
         // Act
         ProjectCreator.Templates
@@ -182,6 +182,7 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
 
         CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
         msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/src/MyClassLibrary/");
+        msbuildMacros.NativeOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/src/MyClassLibrary/native/");
 
         MSBuildOtherProperties msBuildOtherProps = properties.MSBuildOther;
         msBuildOtherProps.MSBuildProjectExtensionPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/src/MyClassLibrary/");
@@ -787,6 +788,7 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
 
         CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
         msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/src/MyClassLibrary/win10-x64/");
+        msbuildMacros.NativeOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/src/MyClassLibrary/win10-x64/native/");
 
         MSBuildOtherProperties msBuildOtherProps = properties.MSBuildOther;
         msBuildOtherProps.MSBuildProjectExtensionPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/src/MyClassLibrary/");
@@ -861,11 +863,11 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
     }
 
     private ProjectCreator SetupDirectoryBuildProps(
-        string centralBuidOutputPath = "$(MSBuildThisFileDirectory)",
+        string centralBuildOutputPath = "$(MSBuildThisFileDirectory)",
         Action<ProjectCreator>? projectFunction = null)
         => ProjectCreator.Templates.DirectoryBuildProps(
             this.ProjectOutput,
             ThisAssemblyDirectory,
-            centralBuidOutputPath,
+            centralBuildOutputPath,
             projectFunction);
 }

--- a/src/CentralBuildOutput.Tests/MSBuild/CommonMSBuildMacros.cs
+++ b/src/CentralBuildOutput.Tests/MSBuild/CommonMSBuildMacros.cs
@@ -44,6 +44,12 @@ internal class CommonMSBuildMacros
     public string IntDir { get; init; } = string.Empty;
 
     /// <summary>
+    /// The native output location for the publish target; includes the trailing backslash '\'. Defaults to the $(OutDir)native\ folder.
+    /// Not yet documented by Microsoft.
+    /// </summary>
+    public string NativeOutputPath { get; init; } = string.Empty;
+
+    /// <summary>
     /// Path to the output file directory. If it's a relative path, output files go to this path appended to the project directory. This path should have a trailing slash. It resolves to the value for the Output Directory property. Don't use $(IntDir) to define this property.
     /// </summary>
     public string OutDir { get; init; } = string.Empty;
@@ -177,6 +183,7 @@ internal class CommonMSBuildMacros
         creator.TryGetPropertyValue(nameof(FrameworkVersion), out string frameworkVersion);
         creator.TryGetPropertyValue(nameof(FxCopDir), out string fxCopDir);
         creator.TryGetPropertyValue(nameof(IntDir), out string intDir);
+        creator.TryGetPropertyValue(nameof(NativeOutputPath), out string nativeOutputPath);
         creator.TryGetPropertyValue(nameof(OutDir), out string outDir);
         creator.TryGetPropertyValue(nameof(Platform), out string platform);
         creator.TryGetPropertyValue(nameof(PlatformShortName), out string platformShortName);
@@ -212,6 +219,7 @@ internal class CommonMSBuildMacros
             FrameworkVersion = frameworkVersion,
             FxCopDir = fxCopDir,
             IntDir = intDir,
+            NativeOutputPath = nativeOutputPath,
             OutDir = outDir,
             Platform = platform,
             PlatformShortName = platformShortName,

--- a/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
+++ b/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.props
@@ -138,6 +138,7 @@
     <BaseOutputPath>$(BaseProjectOutputPath)</BaseOutputPath>
     <OutputPath>$(BaseProjectOutputPath)</OutputPath>
     <PublishDir>$(BaseProjectPublishOutputPath)</PublishDir>
+    <NativeOutputPath>$(PublishDir)native/</NativeOutputPath>
     <VSTestResultsDirectory>$(BaseProjectTestResultsOutputPath)</VSTestResultsDirectory>
     <CoverletOutput>$(BaseProjectTestResultsOutputPath)</CoverletOutput>
   </PropertyGroup>


### PR DESCRIPTION
  - This change defines the `NativeOutputPath` property for [Native AOT deployment](https://learn.microsoft.com/dotnet/core/deploying/native-aot/) output. Fixes #51.