### PR TITLE
Use environment files for output

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,7 +55,7 @@ jobs:
         shell: pwsh
         run: |
           $packageVersion = dotnet nbgv get-version --variable NuGetPackageVersion
-          Write-Host "::set-output name=package_version::$packageVersion"
+          "package_version=$packageVersion" >> $env:GITHUB_OUTPUT
 
       - name: DotNet Format
         run: dotnet format --no-restore --verify-no-changes


### PR DESCRIPTION
  - The `set-output` command has been [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), so we need to change to the new environment files.