### PR TITLE
Patch global.json to 7.0.100 for macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,20 +29,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET 3.1.x SDK
+      - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: |
+            3.1.x
+            6.x
+            7.0.100
+            7.x
 
-      - name: Setup .NET 6.x SDK
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 6.x
-
-      - name: Setup .NET 7.x SDK
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 7.x
+      - name: Patch global.json if necessary
+        shell: pwsh
+        run: ./scripts/PatchGlobalJson.ps1
 
       - name: Install dependencies
         run: dotnet restore

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -21,20 +21,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup .NET 3.1.x SDK
+      - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: |
+            3.1.x
+            6.x
+            7.0.100
+            7.x
 
-      - name: Setup .NET 6.x SDK
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 6.x
-
-      - name: Setup .NET 7.x SDK
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 7.x
+      - name: Patch global.json if necessary
+        shell: pwsh
+        run: ./scripts/PatchGlobalJson.ps1
 
       - name: Install dependencies
         run: dotnet restore

--- a/scripts/PatchGlobalJson.ps1
+++ b/scripts/PatchGlobalJson.ps1
@@ -1,0 +1,9 @@
+if (-not $IsMacOS) {
+    return
+}
+
+Write-Host 'Disabling rollForward to pin to version in global.json.'
+$globalJsonPath = Join-Path $PSScriptRoot '../global.json'
+$globalJson = Get-Content $globalJsonPath -Raw | ConvertFrom-Json
+$globalJson.sdk.rollForward = 'disable'
+$globalJson | ConvertTo-Json | Set-Content -Path $globalJsonPath


### PR DESCRIPTION
  - `dotnet format` is broken on macOS with .NET SDK 7.0.101 (mimicking https://github.com/craigktreasure/Treasure.Utils/pull/31). So, we're installing 7.0.100 in addition to the latest and patching the `global.json` file at build time on macOS to prevent rolling forward to the latest SDK version. This means we'll use the latest on Windows and Linux, but macOS will be pinned o 7.0.100 for now until it's fixed.