### PR TITLE
Fix build due to issues with the .NET SDK

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           dotnet-version: |
             6.x
-            7.0.100
             7.x
 
       - name: Patch global.json if necessary

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,8 +51,9 @@ jobs:
           $packageVersion = dotnet nbgv get-version --variable NuGetPackageVersion
           "package_version=$packageVersion" >> $env:GITHUB_OUTPUT
 
-      - name: DotNet Format
-        run: dotnet format --no-restore --verify-no-changes
+      # Disable until https://github.com/dotnet/format/issues/1800 is fixed.
+      # - name: DotNet Format
+      #   run: dotnet format --no-restore --verify-no-changes
 
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           dotnet-version: |
             6.x
-            7.0.100
             7.x
 
       - name: Patch global.json if necessary

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -35,8 +35,9 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
-      - name: DotNet Format
-        run: dotnet format --no-restore --verify-no-changes
+      # Disable until https://github.com/dotnet/format/issues/1800 is fixed.
+      # - name: DotNet Format
+      #   run: dotnet format --no-restore --verify-no-changes
 
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/scripts/PatchGlobalJson.ps1
+++ b/scripts/PatchGlobalJson.ps1
@@ -1,4 +1,4 @@
-if (-not $IsMacOS) {
+if ($true) {
     return
 }
 


### PR DESCRIPTION
- We previously used a PowerShell script to disable rollForward on macOS. Hoping this is no longer necessary with the updated 7.0.103 SDK.
- Disabled `dotnet format` until the issues in .NET SDK 7.0.200 are fixed.