### PR TITLE
Stop setting the NativeOutputPath

### DIFF
--- a/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
@@ -186,7 +186,6 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
 
         CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
         msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/src/MyClassLibrary/");
-        msbuildMacros.NativeOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/src/MyClassLibrary/native/");
 
         MSBuildOtherProperties msBuildOtherProps = properties.MSBuildOther;
         msBuildOtherProps.MSBuildProjectExtensionPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/src/MyClassLibrary/");
@@ -793,7 +792,6 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
 
         CommonMSBuildMacros msbuildMacros = properties.MSBuildMacros;
         msbuildMacros.PublishDir.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/src/MyClassLibrary/win10-x64/");
-        msbuildMacros.NativeOutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__publish/Debug/AnyCPU/src/MyClassLibrary/win10-x64/native/");
 
         MSBuildOtherProperties msBuildOtherProps = properties.MSBuildOther;
         msBuildOtherProps.MSBuildProjectExtensionPath.MakeRelative(this.ProjectOutput).ShouldBe("__intermediate/src/MyClassLibrary/");

--- a/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.targets
+++ b/src/CentralBuildOutput/Sdk/ConfigureBuildOutput.targets
@@ -137,7 +137,6 @@
     <BaseOutputPath>$(BaseProjectOutputPath)</BaseOutputPath>
     <OutputPath>$(BaseProjectOutputPath)</OutputPath>
     <PublishDir>$(BaseProjectPublishOutputPath)</PublishDir>
-    <NativeOutputPath>$(PublishDir)native/</NativeOutputPath>
     <VSTestResultsDirectory>$(BaseProjectTestResultsOutputPath)</VSTestResultsDirectory>
     <CoverletOutput>$(BaseProjectTestResultsOutputPath)</CoverletOutput>
   </PropertyGroup>
@@ -175,7 +174,6 @@
     -->
     <PropertyGroup Condition=" '$(CentralBuildOutputDotNetStyleProject)' == 'true' ">
       <PublishDir>$(BaseProjectPublishOutputPath)</PublishDir>
-      <NativeOutputPath>$(PublishDir)native/</NativeOutputPath>
     </PropertyGroup>
 
   </Target>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0",
+  "version": "3.0",
   "buildNumberOffset": -1,
   "nugetPackageVersion": {
     "semVer": 2


### PR DESCRIPTION
- **BREAKING:** It turns out, we shouldn't be redirecting the native AOT artifacts to the publish output. Not all of it belongs there and the publish step now places the appropriate AOT bits in the right place anyways. I don't believe this was always the case as that tooling has likely evolved a bit. This change is breaking and will necessitate the 3.0 version bump (do release).
- Setting the `NativeOutputPath` property was also causing bugs because the `NativeOutputPath` is read before our fixup where we add the target framework and RID causing the output to be written to the initial location, but the publish step was expecting it to be in the updated location. By not modifying the `NativeOutputPath`, the issue goes away. Fixes #79.