### PR TITLE
Update CentralBuildOutput version number references

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Example `Directory.Build.props`:
   </PropertyGroup>
 
   <!-- Import the CentralBuildOutput SDK. -->
-  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="2.0.0" />
+  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="3.0.0" />
 </Project>
 ```
 
@@ -93,7 +93,7 @@ The relative path can be adjusted using the `CentralBuildOutputRelativeToPath` M
   </PropertyGroup>
 
   <!-- Import the CentralBuildOutput SDK. -->
-  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="2.0.0" />
+  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="3.0.0" />
 </Project>
 ```
 
@@ -140,7 +140,7 @@ Specify the version number as an attribute of the SDK import:
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   ...
-  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="2.0.0" />
+  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="3.0.0" />
   ...
 </Project>
 ```
@@ -152,7 +152,7 @@ synchronize versions across multiple projects in a solution:
 {
   ...
   "msbuild-sdks": {
-    "Treasure.Build.CentralBuildOutput" : "2.0.0"
+    "Treasure.Build.CentralBuildOutput" : "3.0.0"
   }
 }
 ```

--- a/global.json
+++ b/global.json
@@ -6,6 +6,6 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.0",
-    "Treasure.Build.CentralBuildOutput": "2.0.0"
+    "Treasure.Build.CentralBuildOutput": "3.0.0"
   }
 }

--- a/samples/CentralBuildOutput/Directory.Build.props
+++ b/samples/CentralBuildOutput/Directory.Build.props
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <!-- Import the CentralBuildOutput SDK. -->
-  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="1.0.17" />
+  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="3.0.0" />
 
 </Project>


### PR DESCRIPTION
Updating the version numbers in the README and the version of the package used by the project itself.