### PR TITLE
Add support for .NET 8 SDK and Runtime

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -203,6 +203,9 @@ csharp_style_expression_bodied_operators = when_on_single_line
 # IDE0090: Use 'new(...)'
 csharp_style_implicit_object_creation_when_type_is_apparent = true
 
+# IDE0290: Use Primary Constructors
+csharp_style_prefer_primary_constructors = false
+
 csharp_indent_labels = one_less_than_current
 csharp_space_around_binary_operators = before_and_after
 csharp_using_directive_placement = inside_namespace

--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -9,6 +9,7 @@ runs:
         dotnet-version: |
             6.x
             7.x
+            8.x
 
     - name: Install .NET tools
       shell: pwsh

--- a/.github/workflows/workflow_build.yml
+++ b/.github/workflows/workflow_build.yml
@@ -55,10 +55,10 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: output_${{ inputs.platform }}
-          path: __output
+          path: __artifacts/bin
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v3
         with:
           name: packages_${{ inputs.platform }}
-          path: __packages
+          path: __artifacts/package

--- a/.github/workflows/workflow_release.yml
+++ b/.github/workflows/workflow_release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: packages_ubuntu
-          path: __packages
+          path: __artifacts/package
 
       - name: Push Treasure.Build.CentralBuildOutput ${{ inputs.package-version }} to NuGet.org
-        run: nuget push __packages/NuGet/Release/Treasure.Build.CentralBuildOutput.*.nupkg -ApiKey ${{ secrets.NUGET_API_KEY }} -Source https://api.nuget.org/v3/index.json -SkipDuplicate
+        run: nuget push __artifacts/package/release/Treasure.Build.CentralBuildOutput.*.nupkg -ApiKey ${{ secrets.NUGET_API_KEY }} -Source https://api.nuget.org/v3/index.json -SkipDuplicate

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,9 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/__output/Debug/AnyCPU/CentralBuildOutput.Tests/net7.0/Treasure.Build.CentralBuildOutput.Tests.dll",
+            "program": "${workspaceFolder}/__artifacts/bin/CentralBuildOutput.Tests/debug_net8.0/Treasure.Build.CentralBuildOutput.Tests.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/__output/Debug/AnyCPU/CentralBuildOutput.Tests/net7.0/",
+            "cwd": "${workspaceFolder}/__artifacts/bin/CentralBuildOutput.Tests/debug_net8.0/",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "internalConsole",
             "stopAtEntry": false

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,13 +4,10 @@
   <PropertyGroup>
     <RepoRootPath>$(MSBuildThisFileDirectory)</RepoRootPath>
     <SourceRootPath>$(MSBuildThisFileDirectory)/src</SourceRootPath>
-    <CentralBuildOutputPath>$(RepoRootPath)</CentralBuildOutputPath>
-    <CentralBuildOutputRelativeToPath>$(SourceRootPath)</CentralBuildOutputRelativeToPath>
-    <BaseArtifactsPath>$(MSBuildThisFileDirectory)__artifacts/</BaseArtifactsPath>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <ArtifactsPath>$(RepoRootPath)__artifacts</ArtifactsPath>
   </PropertyGroup>
 
   <Import Project="$(RepoRootPath)/eng/Defaults.props" />
-
-  <Sdk Name="Treasure.Build.CentralBuildOutput" />
 
 </Project>

--- a/eng/Defaults.targets
+++ b/eng/Defaults.targets
@@ -1,9 +1,5 @@
 <Project>
 
-  <PropertyGroup Condition="'$(IsTestProject)' != 'true'">
-    <ArtifactsPath>$(BaseArtifactsPath)/$(MSBuildProjectName)/</ArtifactsPath>
-  </PropertyGroup>
-
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <Content Include="$(RepoRootPath)xunit.runner.json"
              CopyToOutputDirectory="PreserveNewest" />

--- a/eng/DotNetAnalyzers.props
+++ b/eng/DotNetAnalyzers.props
@@ -8,7 +8,7 @@
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <AnalysisLevel>7.0</AnalysisLevel>
+    <AnalysisLevel>8.0</AnalysisLevel>
   </PropertyGroup>
 
 </Project>

--- a/eng/DotNetDefaults.props
+++ b/eng/DotNetDefaults.props
@@ -10,7 +10,7 @@
     <!-- Sets the C# language version:
       https://docs.microsoft.com/dotnet/csharp/language-reference/configure-language-version#c-language-version-reference
     -->
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>latest</LangVersion>
 
     <!-- Enable implicit usings:
       https://docs.microsoft.com/dotnet/core/project-sdk/overview#implicit-using-directives
@@ -49,8 +49,16 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <MSBuildTreatWarningsAsErrors>$(IsCIBuild)</MSBuildTreatWarningsAsErrors>
-    <TreatWarningsAsErrors>$(IsCIBuild)</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Configure test and code coverage output. -->
+    <BaseTestResultsOutputPath>$(ArtifactsPath)/test-results/</BaseTestResultsOutputPath>
+    <BaseProjectTestResultsOutputPath>$(BaseTestResultsOutputPath)$(MSBuildProjectName)/</BaseProjectTestResultsOutputPath>
+    <VSTestResultsDirectory>$(BaseProjectTestResultsOutputPath)</VSTestResultsDirectory>
+    <CoverletOutput>$(BaseProjectTestResultsOutputPath)</CoverletOutput>
   </PropertyGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,11 +1,10 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "8.0.100",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
-    "Microsoft.Build.NoTargets": "3.7.0",
-    "Treasure.Build.CentralBuildOutput": "3.0.0"
+    "Microsoft.Build.NoTargets": "3.7.0"
   }
 }

--- a/samples/CentralBuildOutput/src/MyClassLibrary/MyClassLibrary.csproj
+++ b/samples/CentralBuildOutput/src/MyClassLibrary/MyClassLibrary.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>Treasure.Build.CentralBuildOutput.Tests</AssemblyName>
     <RootNamespace>Treasure.Build.CentralBuildOutput.Tests</RootNamespace>

--- a/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
@@ -215,7 +215,7 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
         ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
             .SdkCsproj(
                 path: "src/MyClassLibrary/MyClassLibrary.csproj",
-                targetFrameworks: new[] { "netstandard1.6", "netstandard2.0", "netstandard2.1" }));
+                targetFrameworks: ["netstandard1.6", "netstandard2.0", "netstandard2.1"]));
 
         // Assert
         Properties properties = Properties.Load(project);
@@ -851,7 +851,7 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
     private void ValidateBuildOutput(bool buildResult, BuildOutput buildOutput)
     {
         // Fail on a failed build, any warnings, or any errors (presumably also failed build).
-        if (!buildResult || buildOutput.Warnings.Any() || buildOutput.Errors.Any())
+        if (!buildResult || buildOutput.Warnings.Count > 0 || buildOutput.Errors.Count > 0)
         {
             foreach (string warning in buildOutput.Warnings)
             {

--- a/src/CentralBuildOutput.Tests/MSBuild/Properties.cs
+++ b/src/CentralBuildOutput.Tests/MSBuild/Properties.cs
@@ -6,6 +6,11 @@ using Microsoft.Build.Utilities.ProjectCreation;
 
 internal sealed class Properties
 {
+    private static readonly JsonSerializerOptions jsonSerializerOptions = new()
+    {
+        WriteIndented = true,
+    };
+
     public CentralBuildOutputProperties CentralBuildOutput { get; }
 
     public CoverletProperties Coverlet { get; }
@@ -48,8 +53,5 @@ internal sealed class Properties
             MSBuildReservedWellKnownProperties.Load(creator),
             VSTestProperties.Load(creator));
 
-    public override string ToString() => JsonSerializer.Serialize(this, new JsonSerializerOptions()
-    {
-        WriteIndented = true,
-    });
+    public override string ToString() => JsonSerializer.Serialize(this, jsonSerializerOptions);
 }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,7 +8,6 @@
     -->
   <ItemGroup>
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
-    <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="6.1.2" />
     <GlobalPackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This change upgrades to the .NET 8 SDK and tests using the .NET 8 runtime in addition to the other supported runtimes. I've also addressed new analyzer warnings.