### PR TITLE
Support .NET 8 artifacts output

### DIFF
--- a/CentralBuildOutput.sln
+++ b/CentralBuildOutput.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.1.32228.430
+VisualStudioVersion = 17.8.34309.116
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CentralBuildOutput", "src\CentralBuildOutput\CentralBuildOutput.csproj", "{7F38EBD6-9C20-4004-A186-38A9EB01D664}"
 EndProject

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 - [Treasure.Build.CentralBuildOutput](#treasurebuildcentralbuildoutput)
   - [Centrally Managing Build Output](#centrally-managing-build-output)
-  - [Extensibility](#extensibility)
+    - [Build output](#build-output)
+    - [Extensibility and configuration](#extensibility-and-configuration)
+    - [Using with artifacts output](#using-with-artifacts-output)
   - [Controlling SDK versions](#controlling-sdk-versions)
 
 The `Treasure.Build.CentralBuildOutput` MSBuild project SDK allows project tree owners to centralize their build
@@ -14,9 +16,9 @@ output in one place. By default, build output is placed in the project folder in
 will cause all of the build output to be written to a common set of folders in a tree structure that mimics the project
 structure.
 
-This project was heavily inspired by the project SDKs from [MSBuildSdks](https://github.com/microsoft/MSBuildSdks).
+This project was heavily inspired by the project SDKs from [MSBuildSdks][msbuild-sdks].
 
-For more information about MSBuild project SDKs, see [here](https://docs.microsoft.com/visualstudio/msbuild/how-to-use-project-sdk).
+For more information about MSBuild project SDKs, see [here][msbuild-project-sdks].
 
 ## Centrally Managing Build Output
 
@@ -35,13 +37,19 @@ Example `Directory.Build.props`:
   </PropertyGroup>
 
   <!-- Import the CentralBuildOutput SDK. -->
-  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="3.0.0" />
+  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="3.1.0" />
 </Project>
 ```
 
 > **Note:**
 >
 > The version number can be controlled in other ways. See [here](#controlling-sdk-versions).
+
+### Build output
+
+> **Note:**
+>
+> When using .NET 8 [artifacts output][artifacts-output], the build output will be different. See [below](#using-with-artifacts-output) for more details.
 
 Build output folders written to the location defined by the `CentralBuildOutputPath` MSBuild property:
 
@@ -93,7 +101,7 @@ The relative path can be adjusted using the `CentralBuildOutputRelativeToPath` M
   </PropertyGroup>
 
   <!-- Import the CentralBuildOutput SDK. -->
-  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="3.0.0" />
+  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="3.1.0" />
 </Project>
 ```
 
@@ -109,7 +117,7 @@ This would result in the following build output:
 /__test-results/MyClassLibrary.Tests/*
 ```
 
-## Extensibility
+### Extensibility and configuration
 
 Setting the following properties controls how Central Build Output works.
 
@@ -127,9 +135,49 @@ Setting the following properties controls how Central Build Output works.
 | `CustomAfterCentralBuildOutputTargets`  | A list of custom MSBuild projects to import **after** central build output targets are declared.     |
 | `EnableCentralBuildOutput`              | Indicates whether central build output is enabled or not. Set to `false` to disable.                 |
 
+### Using with artifacts output
+
+Since .NET 8's new [artifacts output][artifacts-output] accomplishes many of the same goals as
+`Treasure.Build.CentralBuildOutput`, the SDK will behave differently when used in conjunction with artifacts output.
+Specifically, no changes will be made to artifacts output except that test results and
+[coverlet code coverage][coverlet] output will be output to a `test-results` directory underneath the artifacts output
+path.
+
+[Artifacts output][artifacts-output] can be enabled by setting:
+
+```xml
+<UseArtifactsOutput>true</UseArtifactsOutput>
+```
+
+The artifact output path can also be configured by setting the `ArtifactsPath` property:
+
+```xml
+<ArtifactsPath>$(MSBuildThisFileDirectory)__artifacts</ArtifactsPath>
+```
+
+The `ArtifactsPath` property would be used instead of setting the `CentralBuildOutputPath` property. None of the
+`CentralBuildOutput*` properties defined in [extensibility and configuration](#extensibility-and-configuration) will
+have any effect, but the rest still work.
+
+A simple example `Directory.Build.props` would be:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Define the build output location. -->
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <ArtifactsPath>$(MSBuildThisFileDirectory)__artifacts</ArtifactsPath>
+  </PropertyGroup>
+
+  <!-- Import the CentralBuildOutput SDK. -->
+  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="3.1.0" />
+</Project>
+```
+
 ## Controlling SDK versions
 
-For more detailed information, see the [MSBuild documentation](https://docs.microsoft.com/visualstudio/msbuild/how-to-use-project-sdk).
+For more detailed information, see the [MSBuild documentation][msbuild-project-sdks].
 
 When using an MSBuild Project SDK obtained via NuGet (such as the SDK in this repo) a specific version **must** be
 specified.
@@ -140,7 +188,7 @@ Specify the version number as an attribute of the SDK import:
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   ...
-  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="3.0.0" />
+  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="3.1.0" />
   ...
 </Project>
 ```
@@ -152,7 +200,12 @@ synchronize versions across multiple projects in a solution:
 {
   ...
   "msbuild-sdks": {
-    "Treasure.Build.CentralBuildOutput" : "3.0.0"
+    "Treasure.Build.CentralBuildOutput" : "3.1.0"
   }
 }
 ```
+
+[artifacts-output]: https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output "Artifacts output layout"
+[coverlet]: https://github.com/coverlet-coverage/coverlet "Coverlet"
+[msbuild-project-sdks]: https://learn.microsoft.com/visualstudio/msbuild/how-to-use-project-sdk "Use MSBuild project SDKs"
+[msbuild-sdks]: https://github.com/microsoft/MSBuildSdks

--- a/docs/BuildingAndTesting.md
+++ b/docs/BuildingAndTesting.md
@@ -4,8 +4,8 @@
 
 ### Using Visual Studio
 
-* [Visual Studio 2022 17.4+][download-vs]
-  * You'll also need the [.NET 6 SDK][download-dotnet-6-sdk] and [.NET 7 SDK][download-dotnet-7-sdk].
+* [Visual Studio 2022 17.8+][download-vs]
+  * You'll also need the [.NET 6 SDK][download-dotnet-6-sdk], [.NET 7 SDK][download-dotnet-7-sdk], and [.NET 8 SDK][download-dotnet-8-sdk].
 
 ### Using Visual Studio Code
 
@@ -13,6 +13,7 @@
   * Install recommended extensions.
 * [.NET 6 SDK][download-dotnet-6-sdk]
 * [.NET 7 SDK][download-dotnet-7-sdk]
+* [.NET 8 SDK][download-dotnet-8-sdk]
 
 ## Build the SDK
 
@@ -30,7 +31,16 @@ To run all the tests, simply run the following command:
 dotnet test
 ```
 
+## Helpful tips
+
+There are a bunch of helpful [tips for MSBuild][msbuild-tips]. One of those tips is the `-preprocess[:filepath]` or
+`-pp[:filepath]` to create a single aggregated project file that inlines all of the files that would be imported during
+a build. There are more details in the [MSBuild command-line reference][msbuild-cli-reference].
+
 [download-dotnet-6-sdk]: https://dotnet.microsoft.com/download/dotnet/6.0 "Download .NET 6.0"
 [download-dotnet-7-sdk]: https://dotnet.microsoft.com/download/dotnet/7.0 "Download .NET 7.0"
+[download-dotnet-8-sdk]: https://dotnet.microsoft.com/download/dotnet/8.0 "Download .NET 8.0"
 [download-vs]: https://visualstudio.microsoft.com/downloads/ "Download Visual Studio"
 [download-vs-code]: https://code.visualstudio.com/Download "Download Visual Studio Code"
+[msbuild-tips]: https://github.com/dotnet/msbuild/blob/main/documentation/wiki/MSBuild-Tips-&-Tricks.md "MSBuild Command-Line Switches"
+[msbuild-cli-reference]: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022 "MSBuild command-line reference"

--- a/samples/CentralBuildOutput/CentralBuildOutput.Samples.sln
+++ b/samples/CentralBuildOutput/CentralBuildOutput.Samples.sln
@@ -1,10 +1,14 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.1.32228.430
+VisualStudioVersion = 17.8.34309.116
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{48BD55C6-E98D-44EF-AA02-EE6F714CB978}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyClassLibrary", "src\MyClassLibrary\MyClassLibrary.csproj", "{1D374BE9-5496-410E-889F-F5FBF9096F7B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyClassLibraryUsingArtifacts", "src\MyClassLibraryUsingArtifacts\MyClassLibraryUsingArtifacts.csproj", "{DFFF9BF2-28F1-4EC6-B4C8-8622D8934FC8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyClassLibraryUsingArtifacts.Tests", "src\MyClassLibraryUsingArtifacts.Tests\MyClassLibraryUsingArtifacts.Tests.csproj", "{EEFE1669-A4BA-4245-ADC6-A66F68B280F9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -16,12 +20,22 @@ Global
 		{1D374BE9-5496-410E-889F-F5FBF9096F7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1D374BE9-5496-410E-889F-F5FBF9096F7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1D374BE9-5496-410E-889F-F5FBF9096F7B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DFFF9BF2-28F1-4EC6-B4C8-8622D8934FC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DFFF9BF2-28F1-4EC6-B4C8-8622D8934FC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DFFF9BF2-28F1-4EC6-B4C8-8622D8934FC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DFFF9BF2-28F1-4EC6-B4C8-8622D8934FC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEFE1669-A4BA-4245-ADC6-A66F68B280F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEFE1669-A4BA-4245-ADC6-A66F68B280F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEFE1669-A4BA-4245-ADC6-A66F68B280F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEFE1669-A4BA-4245-ADC6-A66F68B280F9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{1D374BE9-5496-410E-889F-F5FBF9096F7B} = {48BD55C6-E98D-44EF-AA02-EE6F714CB978}
+		{DFFF9BF2-28F1-4EC6-B4C8-8622D8934FC8} = {48BD55C6-E98D-44EF-AA02-EE6F714CB978}
+		{EEFE1669-A4BA-4245-ADC6-A66F68B280F9} = {48BD55C6-E98D-44EF-AA02-EE6F714CB978}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9920436A-B716-455A-8E94-C4DDC01FBE8A}

--- a/samples/CentralBuildOutput/Directory.Build.props
+++ b/samples/CentralBuildOutput/Directory.Build.props
@@ -2,14 +2,23 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
+    <SamplesRoot>$(MSBuildThisFileDirectory)</SamplesRoot>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <!-- Define the build output location. -->
-    <CentralBuildOutputPath>$(MSBuildThisFileDirectory)</CentralBuildOutputPath>
+    <CentralBuildOutputPath>$(SamplesRoot)</CentralBuildOutputPath>
 
     <!-- Adjust the relative path (eliminates the src folder in the build output tree). -->
-    <CentralBuildOutputRelativeToPath>$(MSBuildThisFileDirectory)/src</CentralBuildOutputRelativeToPath>
+    <CentralBuildOutputRelativeToPath>$(SamplesRoot)/src</CentralBuildOutputRelativeToPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('MyClassLibraryUsingArtifacts'))">
+    <!-- Configure artifacts output: https://learn.microsoft.com/dotnet/core/sdk/artifacts-output -->
+    <UseArtifactsOutput>true</UseArtifactsOutput>
   </PropertyGroup>
 
   <!-- Import the CentralBuildOutput SDK. -->
-  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="3.0.0" />
+  <Sdk Name="Treasure.Build.CentralBuildOutput" Version="3.1.0" />
 
 </Project>

--- a/samples/CentralBuildOutput/nuget.config
+++ b/samples/CentralBuildOutput/nuget.config
@@ -3,7 +3,7 @@
   <packageSources>
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="artifacts" value="../../__artifacts/CentralBuildOutput" />
+    <add key="artifacts" value="../../__artifacts/package" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget">

--- a/samples/CentralBuildOutput/src/MyClassLibraryUsingArtifacts.Tests/GlobalUsings.cs
+++ b/samples/CentralBuildOutput/src/MyClassLibraryUsingArtifacts.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/samples/CentralBuildOutput/src/MyClassLibraryUsingArtifacts.Tests/MyClassLibraryUsingArtifacts.Tests.csproj
+++ b/samples/CentralBuildOutput/src/MyClassLibraryUsingArtifacts.Tests/MyClassLibraryUsingArtifacts.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/samples/CentralBuildOutput/src/MyClassLibraryUsingArtifacts.Tests/UnitTest1.cs
+++ b/samples/CentralBuildOutput/src/MyClassLibraryUsingArtifacts.Tests/UnitTest1.cs
@@ -1,0 +1,10 @@
+namespace MyClassLibraryUsingArtifacts.Tests;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+
+    }
+}

--- a/samples/CentralBuildOutput/src/MyClassLibraryUsingArtifacts/Class1.cs
+++ b/samples/CentralBuildOutput/src/MyClassLibraryUsingArtifacts/Class1.cs
@@ -1,0 +1,6 @@
+namespace MyClassLibraryUsingArtifacts;
+
+public class Class1
+{
+
+}

--- a/samples/CentralBuildOutput/src/MyClassLibraryUsingArtifacts/MyClassLibraryUsingArtifacts.csproj
+++ b/samples/CentralBuildOutput/src/MyClassLibraryUsingArtifacts/MyClassLibraryUsingArtifacts.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+</Project>

--- a/src/CentralBuildOutput/Sdk/ConfigureBuildOutputForArtifacts.targets
+++ b/src/CentralBuildOutput/Sdk/ConfigureBuildOutputForArtifacts.targets
@@ -1,0 +1,11 @@
+<Project>
+
+  <PropertyGroup Condition=" '$(EnableCentralBuildOutput)' != 'false' ">
+    <!-- Configure test and code coverage output. -->
+    <BaseTestResultsOutputPath>$(ArtifactsPath)/test-results/</BaseTestResultsOutputPath>
+    <BaseProjectTestResultsOutputPath>$(BaseTestResultsOutputPath)$(MSBuildProjectName)/</BaseProjectTestResultsOutputPath>
+    <VSTestResultsDirectory>$(BaseProjectTestResultsOutputPath)</VSTestResultsDirectory>
+    <CoverletOutput>$(BaseProjectTestResultsOutputPath)</CoverletOutput>
+  </PropertyGroup>
+
+</Project>

--- a/src/CentralBuildOutput/Sdk/Sdk.targets
+++ b/src/CentralBuildOutput/Sdk/Sdk.targets
@@ -7,8 +7,11 @@
   <Import Project="$(CustomBeforeCentralBuildOutputTargets)"
           Condition=" '$(EnableCentralBuildOutput)' != 'false' And '$(CustomBeforeCentralBuildOutputTargets)' != '' And Exists('$(CustomBeforeCentralBuildOutputTargets)') " />
 
-  <!-- Configure build outputs. -->
-  <Import Project="$(MSBuildThisFileDirectory)/ConfigureBuildOutput.targets" />
+  <!-- Configure build outputs when not using artifacts. -->
+  <Import Condition=" '$(UseArtifactsOutput)' != 'true' " Project="$(MSBuildThisFileDirectory)/ConfigureBuildOutput.targets" />
+
+  <!-- Configure build outputs when using artifacts. -->
+  <Import Condition=" '$(UseArtifactsOutput)' == 'true' " Project="$(MSBuildThisFileDirectory)/ConfigureBuildOutputForArtifacts.targets" />
 
   <!--
     Import a user extension if specified.

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.0",
+  "version": "3.1",
   "buildNumberOffset": -1,
   "nugetPackageVersion": {
     "semVer": 2


### PR DESCRIPTION
There is a new feature in .NET 8 that introduces a [artifacts output](https://learn.microsoft.com/dotnet/core/sdk/artifacts-output) that is somewhat similar to what `CentralBuildOutput` was trying to achieve. However, there are a few things that artifacts output (`<UseArtifactsOutput>true</UseArtifactsOutput>`) does not configure: test results output and test coverage output for coverlet. This change will now only configure those missing pieces when using artifacts output.

Fixes #78