### PR TITLE
Remove .NET 7 test support

### DIFF
--- a/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>Treasure.Build.CentralBuildOutput.Tests</AssemblyName>
     <RootNamespace>Treasure.Build.CentralBuildOutput.Tests</RootNamespace>


### PR DESCRIPTION
This change prevents us from testing using .NET 7 as it is EOL on 5/14 (see <https://versionsof.net>).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated target frameworks for better compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->