### PR TITLE
Resolve symlink on macOS differently

### DIFF
--- a/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
@@ -18,7 +18,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Mono.Posix.NETStandard" />
     <PackageReference Include="MSBuild.ProjectCreation" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />

--- a/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
@@ -19,6 +19,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSBuild.ProjectCreation" />
+    <PackageReference Include="Neovolve.Logging.Xunit" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/src/CentralBuildOutput.Tests/MSBuildSdkTestBase.cs
+++ b/src/CentralBuildOutput.Tests/MSBuildSdkTestBase.cs
@@ -10,13 +10,14 @@ public abstract class MSBuildSdkTestBase : MSBuildTestBase, IDisposable
 
     private bool disposedValue;
 
-    private protected TestProjectOutput ProjectOutput { get; } = TestProjectOutput.CreateInTemp();
+    private protected TestProjectOutput ProjectOutput { get; }
 
     protected ITestOutputHelper TestOutput { get; }
 
     protected MSBuildSdkTestBase(ITestOutputHelper testOutput)
     {
         this.TestOutput = testOutput;
+        this.ProjectOutput = TestProjectOutput.CreateInTemp(testOutput);
         this.WriteNuGetConfig();
         this.WriteDirectoryBuildTargets();
     }
@@ -35,6 +36,7 @@ public abstract class MSBuildSdkTestBase : MSBuildTestBase, IDisposable
             {
                 this.ProjectOutput.Dispose();
             }
+
             this.disposedValue = true;
         }
     }
@@ -43,7 +45,7 @@ public abstract class MSBuildSdkTestBase : MSBuildTestBase, IDisposable
         => ProjectCreator.Create().Save(Path.Combine(this.ProjectOutput, "Directory.Build.targets"));
 
     private void WriteNuGetConfig()
-            => File.WriteAllText(
+        => File.WriteAllText(
             Path.Combine(this.ProjectOutput, "NuGet.config"),
             @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>

--- a/src/CentralBuildOutput.Tests/TestProjectOutput.cs
+++ b/src/CentralBuildOutput.Tests/TestProjectOutput.cs
@@ -57,7 +57,11 @@ internal sealed class TestProjectOutput : IDisposable
             // symlink. This prevents us from getting the full path that is
             // actually used later in msbuild. We need to resolve the full
             // path so that our tests can compare apples to apples.
-            tempPath = Mono.Unix.UnixPath.GetCompleteRealPath(tempPath);
+            FileSystemInfo? linkTarget = Directory.ResolveLinkTarget(tempPath, true);
+            if (linkTarget is not null)
+            {
+                tempPath = linkTarget.FullName;
+            }
         }
 
         return tempPath;

--- a/src/CentralBuildOutput.Tests/TestProjectOutput.cs
+++ b/src/CentralBuildOutput.Tests/TestProjectOutput.cs
@@ -63,18 +63,6 @@ internal sealed class TestProjectOutput : IDisposable
 
         logger.LogInformation("Temp path: {TempPath}", tempPath);
 
-        // We can sometimes get a value that is a symlink. This prevents us from
-        // getting the full path that is actually used later in msbuild. We need
-        // to resolve the full path so that our tests can compare apples to
-        // apples.
-        FileSystemInfo? linkTarget = Directory.ResolveLinkTarget(tempPath, true);
-        logger.LogCritical("Temp path is a symlink: {IsSymlink}", linkTarget is not null);
-        if (linkTarget is not null)
-        {
-            tempPath = linkTarget.FullName;
-            logger.LogCritical("Updated temp path: {TempPath}", tempPath);
-        }
-
         return tempPath;
     }
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="IsExternalInit"                                    Version="1.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.9.0" />
     <PackageVersion Include="MSBuild.ProjectCreation"                           Version="11.0.1" />
+    <PackageVersion Include="Neovolve.Logging.Xunit"                            Version="5.0.1" />
     <PackageVersion Include="Shouldly"                                          Version="4.2.1" />
     <PackageVersion Include="xunit"                                             Version="2.7.0" />
     <PackageVersion Include="xunit.runner.visualstudio"                         Version="2.5.7" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,7 +14,6 @@
   <ItemGroup>
     <PackageVersion Include="IsExternalInit"                                    Version="1.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.9.0" />
-    <PackageVersion Include="Mono.Posix.NETStandard"                            Version="1.0.0" />
     <PackageVersion Include="MSBuild.ProjectCreation"                           Version="11.0.1" />
     <PackageVersion Include="Shouldly"                                          Version="4.2.1" />
     <PackageVersion Include="xunit"                                             Version="2.7.0" />


### PR DESCRIPTION
Previously, I had used a library (`Mono.Posix.NETStandard`) to resolve the symlink to the temp path on macOS to get a path that I could compare against after retrieving values from MSBuild. Recently, the default build agents in GitHub were updated to use newer ARM64 machines, which that library does not support. I attempted to use [Directory.ResolveLinkTarget](https://learn.microsoft.com/dotnet/api/system.io.directory.resolvelinktarget) (available as of .NET 6) to resolve the path, but it says it's not a symlink. I'm left with this `/private` prefix. Instead, I am going to use the [RUNNER_TEMP](https://docs.github.com/actions/learn-github-actions/variables#default-environment-variables) environment variable on runners to get a more stable temporary location. Added some logging for future reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved logging and path resolution in test project setup.
- **Chores**
	- Updated package dependencies, enhancing logging capabilities in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->