### PR TITLE
Add .NET 9 and drop .NET 6

### DIFF
--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -7,9 +7,8 @@ runs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-            6.x
-            7.x
             8.x
+            9.x
 
     - name: Install .NET tools
       shell: pwsh

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,12 @@
     -->
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+
+    <!--
+      Enable transitive pinning
+      https://learn.microsoft.com/nuget/consume-packages/central-package-management#transitive-pinning
+      -->
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <!--
@@ -23,6 +29,8 @@
     <PackageVersion Include="MSBuild.ProjectCreation"                           Version="12.0.1" />
     <PackageVersion Include="Neovolve.Logging.Xunit"                            Version="6.1.0" />
     <PackageVersion Include="Shouldly"                                          Version="4.2.1" />
+    <!-- Transitively pinned for newer version for Neovolve.Logging.Xunit. -->
+    <PackageVersion Include="System.Text.Json"                                  Version="9.0.0-rc.2.24473.5" />
     <PackageVersion Include="xunit"                                             Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio"                         Version="2.8.2" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ look like the following:
 ```text
 /__intermediate/src/MyClassLibrary/*
 /__intermediate/src/MyClassLibrary.Tests/*
-/__output/Debug/AnyCPU/src/MyClassLibrary/net6.0/*
-/__output/Debug/AnyCPU/src/MyClassLibrary.Tests/net6.0/*
+/__output/Debug/AnyCPU/src/MyClassLibrary/net8.0/*
+/__output/Debug/AnyCPU/src/MyClassLibrary.Tests/net8.0/*
 /__packages/NuGet/Debug/*
 /__publish/Debug/AnyCPU/src/MyClassLibrary/*
 /__test-results/src/MyClassLibrary.Tests/*
@@ -110,8 +110,8 @@ This would result in the following build output:
 ```text
 /__intermediate/MyClassLibrary/*
 /__intermediate/MyClassLibrary.Tests/*
-/__output/Debug/AnyCPU/MyClassLibrary/net6.0/*
-/__output/Debug/AnyCPU/MyClassLibrary.Tests/net6.0/*
+/__output/Debug/AnyCPU/MyClassLibrary/net8.0/*
+/__output/Debug/AnyCPU/MyClassLibrary.Tests/net8.0/*
 /__packages/NuGet/Debug/*
 /__publish/Debug/AnyCPU/MyClassLibrary/*
 /__test-results/MyClassLibrary.Tests/*

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100-rc.2.24474.11",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   },

--- a/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>Treasure.Build.CentralBuildOutput.Tests</AssemblyName>
     <RootNamespace>Treasure.Build.CentralBuildOutput.Tests</RootNamespace>

--- a/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
@@ -206,7 +206,7 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
     ///     src/MyClassLibrary/MyClassLibrary.csproj
     /// </summary>
     [Fact]
-    public void DefaultConfigurationWithMultiTargetting()
+    public void DefaultConfigurationWithMultiTargeting()
     {
         // Arrange
         this.SetupDirectoryBuildProps();
@@ -215,7 +215,7 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
         ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates
             .SdkCsproj(
                 path: "src/MyClassLibrary/MyClassLibrary.csproj",
-                targetFrameworks: ["netstandard1.6", "netstandard2.0", "netstandard2.1"]));
+                targetFrameworks: ["netstandard2.0", "netstandard2.1"]));
 
         // Assert
         Properties properties = Properties.Load(project);
@@ -223,10 +223,8 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
         CommonMSBuildProperties msbuildProps = properties.MSBuildCommon;
         msbuildProps.OutputPath.MakeRelative(this.ProjectOutput).ShouldBe("__output/Debug/AnyCPU/src/MyClassLibrary/");
 
-        File.Exists("__output/Debug/AnyCPU/src/MyClassLibrary/netstandard1.6/MyClassLibrary.dll").ShouldBeTrue();
         File.Exists("__output/Debug/AnyCPU/src/MyClassLibrary/netstandard2.0/MyClassLibrary.dll").ShouldBeTrue();
         File.Exists("__output/Debug/AnyCPU/src/MyClassLibrary/netstandard2.1/MyClassLibrary.dll").ShouldBeTrue();
-        Directory.Exists("__intermediate/src/MyClassLibrary/Debug/netstandard1.6").ShouldBeTrue();
         Directory.Exists("__intermediate/src/MyClassLibrary/Debug/netstandard2.0").ShouldBeTrue();
         Directory.Exists("__intermediate/src/MyClassLibrary/Debug/netstandard2.1").ShouldBeTrue();
     }
@@ -353,7 +351,7 @@ public class CentralBuildOutputTests : MSBuildSdkTestBase
         // Act
         ProjectCreator project = this.CreateSaveAndBuildProject(() => ProjectCreator.Templates.SdkCsproj(
             path: "src/MyCMakeLibrary/MyCMakeLibrary.proj",
-            sdk: "Microsoft.Build.NoTargets/3.5.6"));
+            sdk: "Microsoft.Build.NoTargets/3.7.56"));
 
         // Assert
         Properties properties = Properties.Load(project);


### PR DESCRIPTION
This change updates to use the .NET 9 SDK and runtime to test the application. It also drops support for .NET 6, though it will continue to work just fine.