### PR TITLE
Enable Dependabot to update the .NET SDK

### DIFF
--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -3,12 +3,16 @@ name: Install tools
 runs:
   using: "composite"
   steps:
-    - name: Setup .NET
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: global.json
+
+    - name: Setup additional .NET SDK versions
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
             8.x
-            9.x
 
     - name: Install .NET tools
       shell: pwsh

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,13 @@ updates:
       patterns:
       - "xunit*"
 
+- package-ecosystem: 'dotnet-sdk'
+  directory: "/"
+  schedule:
+    interval: 'weekly'
+    day: 'tuesday'
+    time: '20:00'
+
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
 
   <!--
     Enable and configure Central Package Manager (CPM)
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <!--
-    Global pacakge references
+    Global package references
     https://learn.microsoft.com/nuget/consume-packages/central-package-management#global-package-references
     -->
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100-rc.2.24474.11",
+    "version": "9.0.101",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   },


### PR DESCRIPTION
This change enables Dependabot to update the .NET SDK per [new release](https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/).