### PR TITLE
Use Windows 2025 for builds

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -9,8 +9,13 @@ jobs:
       max-parallel: 3
       fail-fast: false
       matrix:
-        platform: [ windows, ubuntu, macos ]
+        platform: [
+          { os: windows, buildAgent: windows-2025 },
+          { os: ubuntu, buildAgent: ubuntu-latest },
+          { os: macos, buildAgent: macos-14 }
+        ]
     uses: ./.github/workflows/workflow_build.yml
     secrets: inherit
     with:
-      platform: ${{ matrix.platform }}
+      artifactSuffix: ${{ matrix.platform.os }}
+      buildAgent: ${{ matrix.platform.buildAgent }}

--- a/.github/workflows/workflow_build.yml
+++ b/.github/workflows/workflow_build.yml
@@ -6,9 +6,12 @@ on:
       checkFormat:
         type: boolean
         default: true
-      platform:
+      artifactSuffix:
         type: string
         default: ubuntu
+      buildAgent:
+        type: string
+        default: ubuntu-latest
     outputs:
       package_version:
         description: 'The version of the package that was built.'
@@ -21,7 +24,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: ${{ inputs.platform }}-latest
+    runs-on: ${{ inputs.buildAgent }}
 
     outputs:
       package_version: ${{steps.version.outputs.package_version}}
@@ -54,11 +57,11 @@ jobs:
       - name: Upload output artifact
         uses: actions/upload-artifact@v4
         with:
-          name: output_${{ inputs.platform }}
+          name: output_${{ inputs.artifactSuffix }}
           path: __artifacts/bin
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
         with:
-          name: packages_${{ inputs.platform }}
+          name: packages_${{ inputs.artifactSuffix }}
           path: __artifacts/package


### PR DESCRIPTION
According to [this announcement](https://github.blog/changelog/2024-12-19-windows-server-2025-is-now-in-public-preview/), Windows Server 2025 is now available to use in preview.. Initial build shows it being much faster than previous Windows build agents, so we'll try it out.