### PR TITLE
Update xUnit to v3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,10 +27,11 @@
     <PackageVersion Include="IsExternalInit"                                    Version="1.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.13.0" />
     <PackageVersion Include="MSBuild.ProjectCreation"                           Version="14.0.5" />
-    <PackageVersion Include="Neovolve.Logging.Xunit"                            Version="6.3.0" />
+    <PackageVersion Include="Neovolve.Logging.Xunit.v3"                         Version="7.1.0" />
     <PackageVersion Include="Shouldly"                                          Version="4.3.0" />
-    <PackageVersion Include="xunit"                                             Version="2.9.3" />
+    <PackageVersion Include="xunit.analyzers"                                   Version="1.20.0" />
     <PackageVersion Include="xunit.runner.visualstudio"                         Version="3.0.2" />
+    <PackageVersion Include="xunit.v3"                                          Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutput.Tests.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>Treasure.Build.CentralBuildOutput.Tests</AssemblyName>
     <RootNamespace>Treasure.Build.CentralBuildOutput.Tests</RootNamespace>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,13 +20,17 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSBuild.ProjectCreation" />
-    <PackageReference Include="Neovolve.Logging.Xunit" />
+    <PackageReference Include="Neovolve.Logging.Xunit.v3" />
     <PackageReference Include="Shouldly" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>
@@ -33,18 +38,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\CentralBuildOutput\Sdk\*" Link="Sdk\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\CentralBuildOutput\Sdk\*" Link="Sdk\%(Filename)%(Extension)"
+      CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <!--
-    A hack to use the .NET SDKs version of NuGet.Frameworks.dll, since it has a newer version than what is publicly available.
+    A hack to use the .NET SDKs version of NuGet.Frameworks.dll, since it has a newer version than what
+  is publicly available.
 
     This is not applicable when building from within Visual Studio.
   -->
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent"
+    Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">
     <Copy SourceFiles="$(MSBuildSDKsPath)\..\NuGet.Frameworks.dll"
-          DestinationFolder="$(OutputPath)"
-          ContinueOnError="false" />
+      DestinationFolder="$(OutputPath)"
+      ContinueOnError="false" />
   </Target>
 
 </Project>

--- a/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
+++ b/src/CentralBuildOutput.Tests/CentralBuildOutputTests.cs
@@ -8,7 +8,6 @@ using Treasure.Build.CentralBuildOutput.Tests.Extensions;
 using Treasure.Build.CentralBuildOutput.Tests.MSBuild;
 
 using Xunit;
-using Xunit.Abstractions;
 
 public class CentralBuildOutputTests : MSBuildSdkTestBase
 {

--- a/src/CentralBuildOutput.Tests/MSBuildSdkTestBase.cs
+++ b/src/CentralBuildOutput.Tests/MSBuildSdkTestBase.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.Build.Utilities.ProjectCreation;
 
-using Xunit.Abstractions;
+using Xunit;
 
 public abstract class MSBuildSdkTestBase : MSBuildTestBase, IDisposable
 {

--- a/src/CentralBuildOutput.Tests/TestProjectOutput.cs
+++ b/src/CentralBuildOutput.Tests/TestProjectOutput.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 using Treasure.Build.CentralBuildOutput.Tests.Extensions;
 
-using Xunit.Abstractions;
+using Xunit;
 
 internal sealed class TestProjectOutput : IDisposable
 {


### PR DESCRIPTION
This change updates xUnit to v3 by following the [migration guide](https://xunit.net/docs/getting-started/v3/migration).

Note: Currently using beta bits for `Neovolve.Logging.Xunit.v3`.